### PR TITLE
CI + ReadME + StyleCop + FxCop

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,16 @@
+name: Build
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: windows-2019
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup Nuget.exe
+      uses: warrenbuckley/Setup-Nuget@v1
+    - name: Restore packages
+      run: nuget restore RTCV.sln
+    - name: Setup MSBuild.exe
+      uses: warrenbuckley/Setup-MSBuild@v1
+    - name: Build with MSBuild
+      run: msbuild RTCV.sln

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ x64
 x86
 build
 Output/*
+StyleCop.Cache

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,5 +4,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-rc.108" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>$(SolutionDir)StyleCop.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-rc.108" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Phil Girard & Daniel Barreiro
+Copyright (c) 2018-2020 Phil Girard & Daniel Barreiro
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,11 +1,31 @@
+<p align="center">
+    <a href="https://corrupt.wiki/"><img src="Assets/Graphical Assets/Vanguard/icon.ico" alt="RTCV Icon" /></a>
+</p>
+
+<p align="center">
+    <!-- Github action -->
+    <a href="https://github.com/ircluzar/RTCV/actions?query=workflow%3ABuild+branch%3Amaster"><img src="https://github.com/ircluzar/RTCV/workflows/Build/badge.svg?branch=master" alt="Build status badge" /></a>
+    <!-- Wiki -->
+    <a href="https://corrupt.wiki/"><img src="https://img.shields.io/badge/docs-corrupt.wiki-blue.svg" alt="Docs wiki badge" /></a>
+    <!-- Download -->
+    <a href="https://redscientist.com/rtc"><img src="https://img.shields.io/badge/download-RTC-red.svg" alt="Download badge" /></a>
+    <!-- Discord -->
+    <a href="https://corrupt.wiki/corruptors/rtc/expert#rtc-dev-discord"><img src="https://img.shields.io/discord/279664862836031488.svg" alt="Chat badge" /></a>
+    <!-- Trello -->
+    <a href="https://trello.com/b/9QYo50OC/rtcv"><img src="https://img.shields.io/badge/planning-Trello-blue.svg" alt="Trello badge" /></a>
+</p>
+
 # RTCV - Real-Time Corruptor Vanguard
-Real-Time Corruptor, Vanguard, CorruptCore, NetCore2, RTC Launcher
+
+ > Real-Time Corruptor, Vanguard, CorruptCore, NetCore2, RTC Launcher
 
 Real-Time Corruptor Vanaguard is a Dynamic Corruptor for games. It is a set of libraries that can be rigged up to any program that can load the CLR and works by corrupting data in memory to force glitches. RTCV currently comes with implementations for [Bizhawk](https://github.com/ircluzar/Bizhawk-Vanguard), [Dolphin](https://github.com/NarryG/dolphin-vanguard/), [PCSX2](https://github.com/NarryG/pcsx2-Vanguard), [melonDS](https://github.com/narryg/melonds-vanguard), and [Windows Processes](https://github.com/narryg/processstub-vanguard).
 
-Features:
-- Corrupts in real-time 
-- Supports various emulators via a generic API. Currently comes with Bizhawk, Dolphin, PCSX2, melonDS, and Windows real-time implementations. 
+Icon graciously provided by [ShyGuyXXL](https://twitter.com/shyguyxxl)
+
+## Features
+- Corrupts in real-time
+- Supports various emulators via a generic API. Currently comes with Bizhawk, Dolphin, PCSX2, melonDS, and Windows real-time implementations.
 - Supports corrupting files on-disk via the FileStub implementation, as well as including specialized support for certain kinds of files (WiiU games via CemuStub & Unity games via UnityStub).
 - Many corruption engines with customizable algorithms
 - Easy start option for autocorrupt
@@ -22,11 +42,13 @@ Features:
 - The Vector Engine is a specialty corruption engine designed for 3D systems. The included lists target systems that support IEEE754 Floating Point values
 - The Custom Engine allows you to create your own engine using the various corruption parameters.
 
+## Development
+### Recommended: Visual Studio 2019
+[Visual Studio 2019: Community Edition](https://visualstudio.microsoft.com/vs/community/) is a free IDE for open-source projects, and is recommended for RTCV.
 
-Please consult the Official Wiki for software documentation. https://corrupt.wiki
+### Without Visual Studio
 
-Download link: http://redscientist.com/rtc
-Trello: https://trello.com/b/9QYo50OC/rtcv
-
-
-Icon graciously provided by [ShyGuyXXL](https://twitter.com/shyguyxxl)
+1. Install [chocolatey](https://chocolatey.org/install)
+1. `cinst -y visualstudio2019buildtools nuget.commandline`
+1. `nuget restore RTCV.sln`
+1. `msbuild.exe`

--- a/Source/Frontend/StandaloneRTC/Loading.Designer.cs
+++ b/Source/Frontend/StandaloneRTC/Loading.Designer.cs
@@ -1,38 +1,38 @@
 ﻿namespace StandaloneRTC
 {
-	partial class Loader
-	{
-		/// <summary>
-		/// Required designer variable.
-		/// </summary>
-		private System.ComponentModel.IContainer components = null;
+    partial class Loader
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
 
-		/// <summary>
-		/// Clean up any resources being used.
-		/// </summary>
-		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-		protected override void Dispose(bool disposing)
-		{
-			if (disposing && (components != null))
-			{
-				components.Dispose();
-			}
-			base.Dispose(disposing);
-		}
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
 
-		#region Windows Form Designer generated code
+        #region Windows Form Designer generated code
 
-		/// <summary>
-		/// Required method for Designer support - do not modify
-		/// the contents of this method with the code editor.
-		/// </summary>
-		private void InitializeComponent()
-		{
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Loader));
             this.SuspendLayout();
-            // 
+            //
             // Loader
-            // 
+            //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(178, 13);
@@ -44,9 +44,9 @@
             this.Load += new System.EventHandler(this.Form1_Load);
             this.ResumeLayout(false);
 
-		}
+        }
 
-		#endregion
-	}
+        #endregion
+    }
 }
 

--- a/Source/Frontend/StandaloneRTC/Loading.cs
+++ b/Source/Frontend/StandaloneRTC/Loading.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Windows.Forms;
-using RTCV.UI;
-
-namespace StandaloneRTC
+﻿namespace StandaloneRTC
 {
+    using System;
+    using System.IO;
+    using System.Linq;
+    using System.Reflection;
+    using System.Windows.Forms;
+    using RTCV.UI;
+
     public partial class Loader : UI_Extensions.RTC_Standalone_Form
     {
         public Loader(string[] args)

--- a/Source/Frontend/StandaloneRTC/Program.cs
+++ b/Source/Frontend/StandaloneRTC/Program.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.IO;
-using System.Reflection;
-using System.Threading;
-using System.Windows.Forms;
-
-namespace StandaloneRTC
+﻿namespace StandaloneRTC
 {
+    using System;
+    using System.IO;
+    using System.Reflection;
+    using System.Threading;
+    using System.Windows.Forms;
+
     static class Program
     {
         static Form loaderObject;
@@ -50,7 +50,7 @@ namespace StandaloneRTC
         }
 
         /// <summary>
-        /// Global exceptions in Non User Interfarce(other thread) antipicated error
+        /// Global exceptions in Non User Interface(other thread) anticipated error
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
@@ -62,7 +62,7 @@ namespace StandaloneRTC
         }
 
         /// <summary>
-        /// Global exceptions in User Interfarce antipicated error
+        /// Global exceptions in User Interface anticipated error
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>

--- a/Source/Frontend/StandaloneRTC/Properties/AssemblyInfo.cs
+++ b/Source/Frontend/StandaloneRTC/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("StandaloneRTC")]
@@ -13,8 +13,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -24,11 +24,11 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]

--- a/Source/Frontend/StandaloneRTC/StandaloneRTC.csproj
+++ b/Source/Frontend/StandaloneRTC/StandaloneRTC.csproj
@@ -12,6 +12,8 @@
     <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <CodeAnalysisRuleSet>..\..\..\StyleCop.ruleset</CodeAnalysisRuleSet>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -56,7 +58,6 @@
     <PlatformTarget>x64</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>..\..\..\Build\</OutputPath>
@@ -67,7 +68,6 @@
     <PlatformTarget>x64</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <PlatformTarget>x86</PlatformTarget>
@@ -144,7 +144,7 @@
   <PropertyGroup>
     <PostBuildEvent>rd /s /q "cs", "pl", "pt-BR", "tr", "de", "en", "es", "fr", "it", "ja", "ko", "ru", "zh-Hans", "zh-Hant"</PostBuildEvent>
   </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/Source/Frontend/UI/AutoKillSwitch.cs
+++ b/Source/Frontend/UI/AutoKillSwitch.cs
@@ -1,13 +1,13 @@
-using System;
-using System.Diagnostics;
-using System.IO;
-using System.Media;
-using System.Windows.Forms;
-using RTCV.Common;
-using RTCV.NetCore;
-
 namespace RTCV.UI
 {
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Media;
+    using System.Windows.Forms;
+    using RTCV.Common;
+    using RTCV.NetCore;
+
     public static class AutoKillSwitch
     {
         public static int MaxMissedPulses = 25;
@@ -75,7 +75,7 @@ namespace RTCV.UI
 
         public static void KillEmulator(bool forceBypass = false)
         {
-            logger.Trace("Entered KillEmulator {ShouldKillswitchFire} {UICore.FirstConnect} {!forceBypass} {!S.GET<UI_CoreForm>().cbUseAutoKillSwitch.Checked} {!forceBypass}", ShouldKillswitchFire, UICore.FirstConnect, !forceBypass, !S.GET<UI_CoreForm>().cbUseAutoKillSwitch.Checked, !forceBypass); 
+            logger.Trace("Entered KillEmulator {ShouldKillswitchFire} {UICore.FirstConnect} {!forceBypass} {!S.GET<UI_CoreForm>().cbUseAutoKillSwitch.Checked} {!forceBypass}", ShouldKillswitchFire, UICore.FirstConnect, !forceBypass, !S.GET<UI_CoreForm>().cbUseAutoKillSwitch.Checked, !forceBypass);
             if (!ShouldKillswitchFire || (UICore.FirstConnect && !forceBypass) || (!S.GET<UI_CoreForm>().cbUseAutoKillSwitch.Checked && !forceBypass))
             {
                 logger.Trace("Exited KillEmulator {ShouldKillswitchFire} {UICore.FirstConnect} {!forceBypass} {!S.GET<UI_CoreForm>().cbUseAutoKillSwitch.Checked} {!forceBypass}", ShouldKillswitchFire, UICore.FirstConnect, !forceBypass, !S.GET<UI_CoreForm>().cbUseAutoKillSwitch.Checked, !forceBypass);

--- a/Source/Frontend/UI/Components/Blast Editor/RTC_ColumnSelector_Form.cs
+++ b/Source/Frontend/UI/Components/Blast Editor/RTC_ColumnSelector_Form.cs
@@ -1,13 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Windows.Forms;
-using RTCV.Common;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Data;
+    using System.Linq;
+    using System.Text;
+    using System.Windows.Forms;
+    using RTCV.Common;
+
     public partial class ColumnSelector : Form, IAutoColorize
     {
         public ColumnSelector()

--- a/Source/Frontend/UI/Components/Blast Editor/RTC_SanitizeTool_Form.cs
+++ b/Source/Frontend/UI/Components/Blast Editor/RTC_SanitizeTool_Form.cs
@@ -1,13 +1,12 @@
-using System;
-using System.Linq;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using RTCV.Common;
-using NLog.LayoutRenderers;
-
 namespace RTCV.UI
 {
+    using System;
+    using System.Linq;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+    using RTCV.Common;
+
     public partial class RTC_SanitizeTool_Form : Form, IAutoColorize
     {
         public BlastLayer originalBlastLayer = null;
@@ -31,7 +30,7 @@ namespace RTCV.UI
                 }
             }
         }
-        
+
         public static void OpenSanitizeTool(BlastLayer bl = null)
         {
             S.GET<RTC_SanitizeTool_Form>().Close();
@@ -69,7 +68,6 @@ namespace RTCV.UI
 
             stf.UpdateSanitizeProgress();
             stf.ShowDialog();
-
         }
 
         private void RTC_NewBlastEditorForm_Load(object sender, EventArgs e)
@@ -172,7 +170,6 @@ namespace RTCV.UI
             be.Show();
             be.WindowState = FormWindowState.Normal;
             be.BringToFront();
-            
         }
 
         private void btnLeaveSubstractChanges_Click(object sender, EventArgs e)
@@ -231,7 +228,7 @@ namespace RTCV.UI
             }
 
             T Cast<T>(object obj, T type) { return (T)obj; }
-            var modified = Cast(lastItem, new { Text = "", Value = new BlastLayer() }); ;
+            var modified = Cast(lastItem, new { Text = "", Value = new BlastLayer() });
 
             BlastLayer bl = (BlastLayer)modified.Value.Clone();
             S.GET<RTC_NewBlastEditor_Form>().LoadBlastlayer(bl);
@@ -269,7 +266,7 @@ namespace RTCV.UI
 
             int original_remainder = originalSize;
             int original_maxsteps = 0;
-            while(original_remainder>1)
+            while (original_remainder>1)
             {
                 original_remainder = original_remainder / 2;
                 original_maxsteps++;
@@ -295,7 +292,7 @@ namespace RTCV.UI
         private void btnStartSanitizing_Click(object sender, EventArgs e)
         {
             btnStartSanitizing.Visible = false;
-            
+
 
             S.GET<RTC_NewBlastEditor_Form>().dgvBlastEditor.ClearSelection();
             S.GET<RTC_NewBlastEditor_Form>().btnDisable50_Click(null, null);
@@ -345,7 +342,6 @@ namespace RTCV.UI
         {
             if (S.GET<RTC_NewBlastEditor_Form>().AddStashToStockpile())
                 this.Close();
-
         }
         private void btnAddToStash_Click(object sender, EventArgs e)
         {
@@ -357,6 +353,5 @@ namespace RTCV.UI
             //S.GET<RTC_NewBlastEditor_Form>().LoadBlastlayer(originalBlastLayer);
             this.Close();
         }
-
     }
 }

--- a/Source/Frontend/UI/Components/Containers/RTC_ListBox_Form.cs
+++ b/Source/Frontend/UI/Components/Containers/RTC_ListBox_Form.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.Data;
-using System.Linq;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using static RTCV.UI.UI_Extensions;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Data;
+    using System.Linq;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_ListBox_Form : ComponentForm, IBlockable
     {
         private ComponentForm[] childForms;

--- a/Source/Frontend/UI/Components/Containers/RTC_SelectBox_Form.cs
+++ b/Source/Frontend/UI/Components/Containers/RTC_SelectBox_Form.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Windows.Forms;
-using static RTCV.UI.UI_Extensions;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Windows.Forms;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_SelectBox_Form : ComponentForm, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);

--- a/Source/Frontend/UI/Components/Controls/HexTextBox.cs
+++ b/Source/Frontend/UI/Components/Controls/HexTextBox.cs
@@ -1,12 +1,12 @@
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Windows.Forms;
-
 namespace RTCV.UI.Components.Controls
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Text;
+    using System.Windows.Forms;
+
     public interface INumberBox
     {
         bool Nullable { get; }

--- a/Source/Frontend/UI/Components/Controls/InputCompositeWidget.cs
+++ b/Source/Frontend/UI/Components/Controls/InputCompositeWidget.cs
@@ -1,10 +1,9 @@
 ﻿//https://github.com/TASVideos/BizHawk/blob/master/BizHawk.Client.EmuHawk/config/InputCompositeWidget.cs
-
-using System;
-using System.Windows.Forms;
-
 namespace RTCV.UI.Components.Controls
 {
+    using System;
+    using System.Windows.Forms;
+
     public partial class InputCompositeWidget : UserControl
     {
         public InputCompositeWidget()

--- a/Source/Frontend/UI/Components/Controls/InputWidget.cs
+++ b/Source/Frontend/UI/Components/Controls/InputWidget.cs
@@ -1,14 +1,13 @@
 ﻿//Based on https://github.com/TASVideos/BizHawk/blob/master/BizHawk.Client.EmuHawk/config/InputWidget.cs
-
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Windows.Forms;
-
 namespace RTCV.UI.Components.Controls
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Drawing;
+    using System.Linq;
+    using System.Runtime.InteropServices;
+    using System.Windows.Forms;
+
     public sealed class InputWidget : TextBox
     {
         // TODO: when binding, make sure that the new key combo is not in one of the other bindings

--- a/Source/Frontend/UI/Components/Controls/ListBoxExtended.cs
+++ b/Source/Frontend/UI/Components/Controls/ListBoxExtended.cs
@@ -1,9 +1,9 @@
-﻿using System.Drawing;
-using System.Runtime.InteropServices;
-using System.Windows.Forms;
-
-namespace RTCV.UI.Components.Controls
+﻿namespace RTCV.UI.Components.Controls
 {
+    using System.Drawing;
+    using System.Runtime.InteropServices;
+    using System.Windows.Forms;
+
     public class ListBoxExtended : ListBox
     {
         [DllImport("user32")]

--- a/Source/Frontend/UI/Components/Controls/MultiTrackBar.cs
+++ b/Source/Frontend/UI/Components/Controls/MultiTrackBar.cs
@@ -1,10 +1,10 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Windows.Forms;
-
-namespace RTCV.UI.Components.Controls
+﻿namespace RTCV.UI.Components.Controls
 {
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Windows.Forms;
+
     public partial class MultiTrackBar : UserControl
     {
         public event EventHandler<ValueUpdateEventArgs> ValueChanged;
@@ -186,7 +186,7 @@ namespace RTCV.UI.Components.Controls
 
         private void TbControlValue_MouseWheel(object sender, MouseEventArgs e)
         {
-            ((HandledMouseEventArgs)e).Handled = true;//disable default mouse wheel
+            ((HandledMouseEventArgs)e).Handled = true; //disable default mouse wheel
             if (e.Delta > 0)
             {
                 if (tbControlValue.Value + e.Delta <= tbControlValue.Maximum)

--- a/Source/Frontend/UI/Components/Controls/MultiUpDown.cs
+++ b/Source/Frontend/UI/Components/Controls/MultiUpDown.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.ComponentModel;
-using System.Drawing;
-using System.Windows.Forms;
-
-namespace RTCV.UI.Components.Controls
+﻿namespace RTCV.UI.Components.Controls
 {
+    using System;
+    using System.ComponentModel;
+    using System.Drawing;
+    using System.Windows.Forms;
+
     public partial class MultiUpDown : SpecControl<decimal>
     {
         [Description("Whether or not the NumericUpDown should use hex"), Category("Data")]

--- a/Source/Frontend/UI/Components/Controls/OpenToolButton.cs
+++ b/Source/Frontend/UI/Components/Controls/OpenToolButton.cs
@@ -1,15 +1,8 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-
 namespace RTCV.UI.Components.Controls
 {
+    using System;
+    using System.Windows.Forms;
+
     public partial class OpenToolButton : UserControl
     {
         public OpenToolButton(string name, string buttonText, Action onClickedAction)

--- a/Source/Frontend/UI/Components/Controls/SavestateHolder.cs
+++ b/Source/Frontend/UI/Components/Controls/SavestateHolder.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Drawing;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-
-namespace RTCV.UI.Components.Controls
+﻿namespace RTCV.UI.Components.Controls
 {
+    using System;
+    using System.Drawing;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+
     public partial class SavestateHolder : UserControl
     {
         private StashKey _sk = null;

--- a/Source/Frontend/UI/Components/Controls/SavestateList.cs
+++ b/Source/Frontend/UI/Components/Controls/SavestateList.cs
@@ -1,18 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Drawing.Design;
-using System.IO;
-using System.Linq;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using RTCV.Common;
-
-namespace RTCV.UI.Components.Controls
+﻿namespace RTCV.UI.Components.Controls
 {
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Data;
+    using System.Drawing;
+    using System.Drawing.Design;
+    using System.IO;
+    using System.Linq;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+    using RTCV.Common;
+
     public partial class SavestateList : UserControl
     {
         public List<SavestateHolder> controlList;

--- a/Source/Frontend/UI/Components/Controls/SpecControl.cs
+++ b/Source/Frontend/UI/Components/Controls/SpecControl.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Windows.Forms;
-
-namespace RTCV.UI.Components.Controls
+﻿namespace RTCV.UI.Components.Controls
 {
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Windows.Forms;
+
     public abstract class SpecControl<T> : UserControl where T : new()
     {
         internal bool GeneralUpdateFlag = false; //makes other events ignore firing

--- a/Source/Frontend/UI/Components/Engine Config/RTC_CorruptionEngine_Form.cs
+++ b/Source/Frontend/UI/Components/Engine Config/RTC_CorruptionEngine_Form.cs
@@ -1,13 +1,13 @@
-using System;
-using System.Drawing;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using RTCV.Common;
-using static RTCV.UI.UI_Extensions;
-
 namespace RTCV.UI
 {
+    using System;
+    using System.Drawing;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+    using RTCV.Common;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_CorruptionEngine_Form : ComponentForm, IAutoColorize, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);

--- a/Source/Frontend/UI/Components/Engine Config/RTC_GeneralParameters_Form.cs
+++ b/Source/Frontend/UI/Components/Engine Config/RTC_GeneralParameters_Form.cs
@@ -1,12 +1,12 @@
-using System;
-using System.Windows.Forms;
-using RTCV.Common;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using static RTCV.UI.UI_Extensions;
-
 namespace RTCV.UI
 {
+    using System;
+    using System.Windows.Forms;
+    using RTCV.Common;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_GeneralParameters_Form : ComponentForm, IAutoColorize, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);

--- a/Source/Frontend/UI/Components/Engine Config/RTC_MemoryDomains_Form.cs
+++ b/Source/Frontend/UI/Components/Engine Config/RTC_MemoryDomains_Form.cs
@@ -1,17 +1,16 @@
-using System;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using RTCV.Common;
-using static RTCV.UI.UI_Extensions;
-using System.Drawing;
-using RTCV.UI.Components.Controls;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Data;
+    using System.Drawing;
+    using System.Linq;
+    using System.Text;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+    using RTCV.Common;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_MemoryDomains_Form : ComponentForm, IAutoColorize, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);
@@ -184,7 +183,7 @@ namespace RTCV.UI
                 var AutoLimitedDomains = MemoryDomains.AllMemoryInterfaces.Where(it => it.Value is VirtualMemoryDomain vmd && vmd.Name.Contains("->")).ToList();
 
                 if (vectorLimiter != null)
-                { 
+                {
                     ContextMenuStrip cms = new ContextMenuStrip();
                     //cms.Items.Add($"Generate VMD using Vector Limiter", null, (ob, ev) => {}).Enabled = false;
                     var lbGen = new ToolStripLabel($"Limiter Profiler");
@@ -210,7 +209,6 @@ namespace RTCV.UI
                                 S.GET<RTC_VmdLimiterProfiler_Form>().AutoProfile(MemoryDomains.AllMemoryInterfaces[domain], limiter);
                             }
                         }
-
                     }).Enabled = (AutoLimitedDomains.Count > 0);
 
 

--- a/Source/Frontend/UI/Components/Glitch Harvester/RTC_GlitchHarvesterBlast_Form.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/RTC_GlitchHarvesterBlast_Form.cs
@@ -1,18 +1,18 @@
-using System;
-using System.Collections.Generic;
-using System.Data;
-using System.Diagnostics;
-using System.Drawing;
-using System.IO;
-using System.Linq;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using RTCV.Common;
-using static RTCV.UI.UI_Extensions;
-
 namespace RTCV.UI
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Data;
+    using System.Diagnostics;
+    using System.Drawing;
+    using System.IO;
+    using System.Linq;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+    using RTCV.Common;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_GlitchHarvesterBlast_Form : ComponentForm, IAutoColorize, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);

--- a/Source/Frontend/UI/Components/Glitch Harvester/RTC_GlitchHarvesterIntensity_Form.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/RTC_GlitchHarvesterIntensity_Form.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using RTCV.Common;
-using static RTCV.UI.UI_Extensions;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+    using RTCV.Common;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_GlitchHarvesterIntensity_Form : ComponentForm, IAutoColorize, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);

--- a/Source/Frontend/UI/Components/Glitch Harvester/RTC_SavestateManager_Form.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/RTC_SavestateManager_Form.cs
@@ -1,20 +1,20 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-using Newtonsoft.Json;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using RTCV.Common;
-using static RTCV.UI.UI_Extensions;
-
 namespace RTCV.UI
 {
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Data;
+    using System.Drawing;
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using System.Windows.Forms;
+    using Newtonsoft.Json;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+    using RTCV.Common;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_SavestateManager_Form : ComponentForm, IAutoColorize, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);
@@ -62,7 +62,7 @@ namespace RTCV.UI
                 RtcCore.OnProgressBarUpdate(this, new ProgressBarEventArgs("Committing used states to session", currentProgress += 5));
                 //Commit any used states to the SESSION folder
                 commitUsedStatesToSession();
-                SyncObjectSingleton.FormExecute(() => savestateBindingSource.Clear()); 
+                SyncObjectSingleton.FormExecute(() => savestateBindingSource.Clear());
             }
 
             var extractFolder = import ? "TEMP" : "SSK";
@@ -205,7 +205,7 @@ namespace RTCV.UI
             var ghForm = UI_CanvasForm.GetExtraForm("Glitch Harvester");
             try
             {
-                //We do this here and invoke because our unlock runs at the end of the awaited method, but there's a chance an error occurs 
+                //We do this here and invoke because our unlock runs at the end of the awaited method, but there's a chance an error occurs
                 //Thus, we want this to happen within the try block
                 SyncObjectSingleton.FormExecute(() =>
                 {
@@ -441,7 +441,7 @@ namespace RTCV.UI
             var ghForm = UI_CanvasForm.GetExtraForm("Glitch Harvester");
             try
             {
-                //We do this here and invoke because our unlock runs at the end of the awaited method, but there's a chance an error occurs 
+                //We do this here and invoke because our unlock runs at the end of the awaited method, but there's a chance an error occurs
                 //Thus, we want this to happen within the try block
                 SyncObjectSingleton.FormExecute(() =>
                 {
@@ -484,7 +484,7 @@ namespace RTCV.UI
                 loadSavestateList(false, files[0]);
             }
 
-            //Bring the UI back to normal after a drag+drop to prevent weird merge stuff 
+            //Bring the UI back to normal after a drag+drop to prevent weird merge stuff
             S.GET<RTC_GlitchHarvesterBlast_Form>().RedrawActionUI();
         }
 

--- a/Source/Frontend/UI/Components/Glitch Harvester/RTC_StashHistory_Form.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/RTC_StashHistory_Form.cs
@@ -1,14 +1,14 @@
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using RTCV.Common;
-using static RTCV.UI.UI_Extensions;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Drawing;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+    using RTCV.Common;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_StashHistory_Form : ComponentForm, IAutoColorize, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);
@@ -52,7 +52,7 @@ namespace RTCV.UI
             string Name = "";
             string value = "";
 
-            StashKey sk = (StashKey)lbStashHistory.SelectedItem; ;
+            StashKey sk = (StashKey)lbStashHistory.SelectedItem;
             StockpileManager_UISide.CurrentStashkey = sk;
 
             //If we don't support mixed stockpiles
@@ -221,15 +221,15 @@ namespace RTCV.UI
                 }))).Enabled = (lbStashHistory.SelectedIndex != -1 && lbStashHistory.SelectedItems.Count > 1);
 
                 /*
-				if (!RTC_NetcoreImplementation.isStandaloneUI)
-				{
-					columnsMenu.Items.Add(new ToolStripSeparator());
-					((ToolStripMenuItem)columnsMenu.Items.Add("[Multiplayer] Pull State from peer", null, new EventHandler((ob, ev) =>
-						{
-							S.GET<RTC_Multiplayer_Form>().cbPullStateToGlitchHarvester.Checked = true;
-							RTC_NetcoreImplementation.Multiplayer.SendCommand(new RTC_Command(CommandType.PULLSTATE), false);
-						}))).Enabled = RTC_NetcoreImplementation.Multiplayer != null && RTC_NetcoreImplementation.Multiplayer.side != NetworkSide.DISCONNECTED;
-				}*/
+                if (!RTC_NetcoreImplementation.isStandaloneUI)
+                {
+                    columnsMenu.Items.Add(new ToolStripSeparator());
+                    ((ToolStripMenuItem)columnsMenu.Items.Add("[Multiplayer] Pull State from peer", null, new EventHandler((ob, ev) =>
+                        {
+                            S.GET<RTC_Multiplayer_Form>().cbPullStateToGlitchHarvester.Checked = true;
+                            RTC_NetcoreImplementation.Multiplayer.SendCommand(new RTC_Command(CommandType.PULLSTATE), false);
+                        }))).Enabled = RTC_NetcoreImplementation.Multiplayer != null && RTC_NetcoreImplementation.Multiplayer.side != NetworkSide.DISCONNECTED;
+                }*/
 
                 columnsMenu.Show(this, locate);
             }

--- a/Source/Frontend/UI/Components/Glitch Harvester/RTC_StockpileManager_Form.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/RTC_StockpileManager_Form.cs
@@ -1,18 +1,18 @@
-using System;
-using System.Collections.Generic;
-using System.Data;
-using System.Drawing;
-using System.IO;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.Common;
-using static RTCV.UI.UI_Extensions;
-
 namespace RTCV.UI
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Data;
+    using System.Drawing;
+    using System.IO;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.Common;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_StockpileManager_Form : ComponentForm, IAutoColorize, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);
@@ -123,11 +123,11 @@ namespace RTCV.UI
                     {
                         sks.Add((StashKey)row.Cells[0].Value);
                     }
-                    
+
                     //dgv is stupid.
                     //If you shift-select you get things in the order you'd expect (start > end).
                     //If you ctrl+select, you get things in the reverse order (the most recent selected gets inserted at the start of the list)
-                    if(IsControlDown())
+                    if (IsControlDown())
                         sks.Reverse();
                     StockpileManager_UISide.MergeStashkeys(sks);
 
@@ -260,11 +260,11 @@ namespace RTCV.UI
                 }))).Enabled = (dgvStockpile.SelectedRows.Count >= 1);
 
                 /*
-				if (!RTC_NetcoreImplementation.isStandaloneUI)
-				{
-					((ToolStripMenuItem)columnsMenu.Items.Add("[Multiplayer] Send Selected Item as a Blast", null, new EventHandler((ob, ev) => { RTC_NetcoreImplementation.Multiplayer?.SendBlastlayer(); }))).Enabled = RTC_NetcoreImplementation.Multiplayer != null && RTC_NetcoreImplementation.Multiplayer.side != NetworkSide.DISCONNECTED;
-					((ToolStripMenuItem)columnsMenu.Items.Add("[Multiplayer] Send Selected Item as a Game State", null, new EventHandler((ob, ev) => { RTC_NetcoreImplementation.Multiplayer?.SendStashkey(); }))).Enabled = RTC_NetcoreImplementation.Multiplayer != null && RTC_NetcoreImplementation.Multiplayer.side != NetworkSide.DISCONNECTED;
-				}*/
+                if (!RTC_NetcoreImplementation.isStandaloneUI)
+                {
+                    ((ToolStripMenuItem)columnsMenu.Items.Add("[Multiplayer] Send Selected Item as a Blast", null, new EventHandler((ob, ev) => { RTC_NetcoreImplementation.Multiplayer?.SendBlastlayer(); }))).Enabled = RTC_NetcoreImplementation.Multiplayer != null && RTC_NetcoreImplementation.Multiplayer.side != NetworkSide.DISCONNECTED;
+                    ((ToolStripMenuItem)columnsMenu.Items.Add("[Multiplayer] Send Selected Item as a Game State", null, new EventHandler((ob, ev) => { RTC_NetcoreImplementation.Multiplayer?.SendStashkey(); }))).Enabled = RTC_NetcoreImplementation.Multiplayer != null && RTC_NetcoreImplementation.Multiplayer.side != NetworkSide.DISCONNECTED;
+                }*/
 
                 columnsMenu.Show(this, locate);
             }
@@ -322,7 +322,6 @@ namespace RTCV.UI
 
                 //lbStockpile.RefreshItemsReal();
             }
-
         }
 
         private void btnRemoveSelectedStockpile_Click(object sender, EventArgs e)
@@ -342,7 +341,6 @@ namespace RTCV.UI
                 UnsavedEdits = true;
                 S.GET<RTC_GlitchHarvesterBlast_Form>().RedrawActionUI();
             }
-
         }
 
         private void btnClearStockpile_Click(object sender, EventArgs e)
@@ -377,7 +375,7 @@ namespace RTCV.UI
             var ghForm = UI_CanvasForm.GetExtraForm("Glitch Harvester");
             try
             {
-                //We do this here and invoke because our unlock runs at the end of the awaited method, but there's a chance an error occurs 
+                //We do this here and invoke because our unlock runs at the end of the awaited method, but there's a chance an error occurs
                 //Thus, we want this to happen within the try block
                 UICore.SetHotkeyTimer(false);
 
@@ -486,7 +484,7 @@ namespace RTCV.UI
             var ghForm = UI_CanvasForm.GetExtraForm("Glitch Harvester");
             try
             {
-                //We do this here and invoke because our unlock runs at the end of the awaited method, but there's a chance an error occurs 
+                //We do this here and invoke because our unlock runs at the end of the awaited method, but there's a chance an error occurs
                 //Thus, we want this to happen within the try block
                 UICore.SetHotkeyTimer(false);
                 UICore.LockInterface(false, true);
@@ -698,7 +696,7 @@ namespace RTCV.UI
                 LoadStockpile(files[0]);
             }
 
-            //Bring the UI back to normal after a drag+drop to prevent weird merge stuff 
+            //Bring the UI back to normal after a drag+drop to prevent weird merge stuff
             S.GET<RTC_GlitchHarvesterBlast_Form>().RedrawActionUI();
         }
 

--- a/Source/Frontend/UI/Components/Memory Tools/RTC_DomainAnalytics_Form.cs
+++ b/Source/Frontend/UI/Components/Memory Tools/RTC_DomainAnalytics_Form.cs
@@ -1,17 +1,17 @@
-using System;
-using System.Collections.Generic;
-using System.Data;
-using System.Drawing;
-using System.IO;
-using System.Linq;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using RTCV.Common;
-using static RTCV.UI.UI_Extensions;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Data;
+    using System.Drawing;
+    using System.IO;
+    using System.Linq;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+    using RTCV.Common;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_DomainAnalytics_Form : ComponentForm, IAutoColorize, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);

--- a/Source/Frontend/UI/Components/Memory Tools/RTC_ListGen_Form.cs
+++ b/Source/Frontend/UI/Components/Memory Tools/RTC_ListGen_Form.cs
@@ -1,16 +1,16 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Globalization;
-using System.IO;
-using System.Text.RegularExpressions;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.Common;
-using static RTCV.UI.UI_Extensions;
-
 namespace RTCV.UI
 {
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Globalization;
+    using System.IO;
+    using System.Text.RegularExpressions;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.Common;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_ListGen_Form : ComponentForm, IAutoColorize, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);
@@ -37,7 +37,7 @@ namespace RTCV.UI
 
         private bool isHex(string str)
         {
-            //Hex characters 
+            //Hex characters
             //Trim the 0x off
             string regex = "^((0[Xx])|([xX]))[0-9A-Fa-f]+$";
             return Regex.IsMatch(str, regex);
@@ -90,7 +90,7 @@ namespace RTCV.UI
 
                 string[] lineParts = trimmedLine.Split('-');
 
-                //We can't do a range on anything besides plain old numbers 
+                //We can't do a range on anything besides plain old numbers
                 if (lineParts.Length > 1)
                 {
                     //Hex
@@ -172,7 +172,7 @@ namespace RTCV.UI
 
             IListFilter list;
 
-            if(newList.Contains("?"))
+            if (newList.Contains("?"))
             {
                 list = new NullableByteArrayList();
             }

--- a/Source/Frontend/UI/Components/Memory Tools/RTC_MyLists.cs
+++ b/Source/Frontend/UI/Components/Memory Tools/RTC_MyLists.cs
@@ -1,20 +1,16 @@
-using System;
-using System.Data;
-using System.IO;
-using System.Linq;
-using System.Windows.Forms;
-using System.Xml.Serialization;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using RTCV.Common;
-using static RTCV.UI.UI_Extensions;
-
 namespace RTCV.UI
 {
+    using System;
+    using System.Data;
+    using System.IO;
+    using System.Linq;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.Common;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_MyLists_Form : ComponentForm, IAutoColorize, IBlockable
     {
-        
-
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);
         public new void HandleFormClosing(object s, FormClosingEventArgs e) => base.HandleFormClosing(s, e);
 
@@ -55,7 +51,6 @@ namespace RTCV.UI
 
                 if (File.Exists(listPath))
                     File.Delete(listPath);
-
             }
 
             RefreshLists();
@@ -69,7 +64,7 @@ namespace RTCV.UI
                 Directory.CreateDirectory(RtcCore.listsDir);
 
             var files = Directory.GetFiles(RtcCore.listsDir).OrderBy(it => it.Replace("$",""));
-            foreach(var file in files)
+            foreach (var file in files)
             {
                 string shortfile = file.Substring(file.LastIndexOf('\\') + 1);
                 lbKnownLists.Items.Add(shortfile.Replace("$", "[DISABLED] "));
@@ -79,7 +74,6 @@ namespace RTCV.UI
             btnSaveList.Enabled = false;
             btnRenameList.Enabled = false;
             btnRemoveList.Enabled = false;
-
         }
 
 
@@ -112,7 +106,6 @@ namespace RTCV.UI
             }
 
             File.Move(listPath, path);
-
         }
 
         private void RTC_MyLists_Form_Load(object sender, EventArgs e)
@@ -142,13 +135,13 @@ namespace RTCV.UI
 
             bool allDisabled = true;
 
-            foreach(var item in lbKnownLists.SelectedItems)
+            foreach (var item in lbKnownLists.SelectedItems)
             {
-                if(!item.ToString().Contains("[DISABLED] "))
+                if (!item.ToString().Contains("[DISABLED] "))
                 {
                     allDisabled = false;
                     break;
-                }    
+                }
             }
 
             if (allDisabled)
@@ -180,7 +173,6 @@ namespace RTCV.UI
             {
                 string filename = saveFileDialog1.FileName;
 
-
                 if (File.Exists(filename))
                     File.Delete(filename);
 
@@ -190,13 +182,11 @@ namespace RTCV.UI
 
         private void importList(string path)
         {
-
             string shortPath = path.Substring(path.LastIndexOf('\\') + 1);
             string targetPath = Path.Combine(RtcCore.listsDir, shortPath);
 
             if (File.Exists(targetPath))
             {
-
                 var result = MessageBox.Show("This file already exist in your VMDs folder, do you want to overwrite it?", "Overwrite file?", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
                 if (result == DialogResult.No)
                     return;
@@ -206,9 +196,7 @@ namespace RTCV.UI
 
             File.Copy(path, targetPath);
 
-
             RefreshLists();
-
         }
 
 
@@ -231,7 +219,7 @@ namespace RTCV.UI
 
                 if (btnEnableDisableList.Text.Contains("Disable"))
                 {
-                    if(!isDisabled)
+                    if (!isDisabled)
                     {
                         File.Move(pathEnabled, pathDisabled);
                     }
@@ -243,7 +231,6 @@ namespace RTCV.UI
                         File.Move(pathDisabled, pathEnabled);
                     }
                 }
-                
             }
 
             CorruptCore.Filtering.ResetLoadedListsInUI();
@@ -290,7 +277,6 @@ namespace RTCV.UI
             };
             if (ofd.ShowDialog() == DialogResult.OK)
             {
-                bool notified = false;
                 //string Filename = ofd.FileName.ToString();
                 foreach (string filename in ofd.FileNames)
                 {

--- a/Source/Frontend/UI/Components/Memory Tools/RTC_MyVMDs_Form.cs
+++ b/Source/Frontend/UI/Components/Memory Tools/RTC_MyVMDs_Form.cs
@@ -1,20 +1,14 @@
-using System;
-using System.Data;
-using System.IO;
-using System.Linq;
-using System.Windows.Forms;
-using System.Xml.Serialization;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using RTCV.Common;
-using static RTCV.UI.UI_Extensions;
-
 namespace RTCV.UI
 {
+    using System;
+    using System.IO;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.Common;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_MyVMDs_Form : ComponentForm, IAutoColorize, IBlockable
     {
-        
-
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);
         public new void HandleFormClosing(object s, FormClosingEventArgs e) => base.HandleFormClosing(s, e);
 
@@ -55,7 +49,6 @@ namespace RTCV.UI
 
                 if (File.Exists(vmdPath))
                     File.Delete(vmdPath);
-
             }
 
             RefreshVMDs();
@@ -69,7 +62,7 @@ namespace RTCV.UI
                 Directory.CreateDirectory(RtcCore.vmdsDir);
 
             var files = Directory.GetFiles(RtcCore.vmdsDir);
-            foreach(var file in files)
+            foreach (var file in files)
             {
                 string shortfile = file.Substring(file.LastIndexOf('\\') + 1);
                 lbLoadedVmdList.Items.Add(shortfile);
@@ -79,7 +72,6 @@ namespace RTCV.UI
             btnSaveVmd.Enabled = false;
             btnRenameVMD.Enabled = false;
             btnUnloadVmd.Enabled = false;
-
         }
 
 
@@ -112,7 +104,6 @@ namespace RTCV.UI
             }
 
             File.Move(vmdPath, path);
-
         }
 
         private void RTC_MyVMDs_Form_Load(object sender, EventArgs e)
@@ -139,8 +130,6 @@ namespace RTCV.UI
 
             btnLoadVmd.Enabled = true;
             btnUnloadVmd.Enabled = true;
-
-
         }
 
         private void btnSaveVmd_Click(object sender, EventArgs e)
@@ -174,13 +163,11 @@ namespace RTCV.UI
 
         private void importVmd(string path)
         {
-
             string shortPath = path.Substring(path.LastIndexOf('\\') + 1);
             string targetPath = Path.Combine(RtcCore.vmdsDir, shortPath);
 
             if (File.Exists(targetPath))
             {
-
                 var result = MessageBox.Show("This file already exist in your VMDs folder, do you want to overwrite it?", "Overwrite file?", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
                 if (result == DialogResult.No)
                     return;
@@ -192,7 +179,6 @@ namespace RTCV.UI
 
 
             RefreshVMDs();
-
         }
 
 
@@ -203,7 +189,6 @@ namespace RTCV.UI
 
             foreach (var item in lbLoadedVmdList.SelectedItems)
             {
-
                 string vmdName = item.ToString();
                 string path = Path.Combine(RtcCore.vmdsDir, vmdName);
 
@@ -219,7 +204,6 @@ namespace RTCV.UI
                     break;
                 }
             }
-
         }
 
         private void btnRenameVMD_Click(object sender, EventArgs e)
@@ -251,7 +235,6 @@ namespace RTCV.UI
             };
             if (ofd.ShowDialog() == DialogResult.OK)
             {
-                bool notified = false;
                 //string Filename = ofd.FileName.ToString();
                 foreach (string filename in ofd.FileNames)
                 {

--- a/Source/Frontend/UI/Components/Memory Tools/RTC_OpenTools_Form.cs
+++ b/Source/Frontend/UI/Components/Memory Tools/RTC_OpenTools_Form.cs
@@ -1,13 +1,13 @@
-using System;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using RTCV.Common;
-using RTCV.UI.Components.Controls;
-using static RTCV.UI.UI_Extensions;
-
 namespace RTCV.UI
 {
+    using System;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+    using RTCV.Common;
+    using RTCV.UI.Components.Controls;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_OpenTools_Form : ComponentForm, IAutoColorize, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);

--- a/Source/Frontend/UI/Components/Memory Tools/RTC_VmdAct_Form.cs
+++ b/Source/Frontend/UI/Components/Memory Tools/RTC_VmdAct_Form.cs
@@ -1,18 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Data;
-using System.Drawing;
-using System.IO;
-using System.Linq;
-using System.Windows.Forms;
-using System.Xml.Serialization;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using RTCV.Common;
-using static RTCV.UI.UI_Extensions;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Data;
+    using System.Drawing;
+    using System.IO;
+    using System.Linq;
+    using System.Windows.Forms;
+    using System.Xml.Serialization;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+    using RTCV.Common;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_VmdAct_Form : ComponentForm, IAutoColorize, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);
@@ -549,7 +549,7 @@ namespace RTCV.UI
                                 proto.AddSingles.Add(safeaddress + i);
                             }
                             //[] _addresses = { safeaddress, safeaddress + mi.WordSize };
-                            //	proto.addRanges.Add(_addresses);
+                            //    proto.addRanges.Add(_addresses);
                         }
                     }
                 }

--- a/Source/Frontend/UI/Components/Memory Tools/RTC_VmdGen_Form.cs
+++ b/Source/Frontend/UI/Components/Memory Tools/RTC_VmdGen_Form.cs
@@ -1,14 +1,14 @@
-using System;
-using System.Data;
-using System.Globalization;
-using System.Linq;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.Common;
-using static RTCV.UI.UI_Extensions;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Data;
+    using System.Globalization;
+    using System.Linq;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.Common;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_VmdGen_Form : ComponentForm, IAutoColorize, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);

--- a/Source/Frontend/UI/Components/Memory Tools/RTC_VmdLimiterProfiler_Form.cs
+++ b/Source/Frontend/UI/Components/Memory Tools/RTC_VmdLimiterProfiler_Form.cs
@@ -1,15 +1,15 @@
-using System;
-using System.Data;
-using System.Globalization;
-using System.Linq;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using RTCV.Common;
-using static RTCV.UI.UI_Extensions;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Data;
+    using System.Globalization;
+    using System.Linq;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+    using RTCV.Common;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_VmdLimiterProfiler_Form : ComponentForm, IAutoColorize, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);
@@ -225,7 +225,6 @@ namespace RTCV.UI
 
             if (!AutoGenerate)
             {
-
                 //Selects back the VMD Pool menu
                 foreach (var item in UICore.mtForm.cbSelectBox.Items)
                 {
@@ -235,7 +234,6 @@ namespace RTCV.UI
                         break;
                     }
                 }
-
             }
 
             return true;
@@ -248,7 +246,7 @@ namespace RTCV.UI
             var ceForm = S.GET<RTC_CorruptionEngine_Form>();
 
             foreach (var item in cbSelectedMemoryDomain.Items)
-                if(item.ToString() == mi.ToString())
+                if (item.ToString() == mi.ToString())
                 {
                     cbSelectedMemoryDomain.SelectedItem = item;
                     break;
@@ -270,7 +268,6 @@ namespace RTCV.UI
             tbVmdName.Text = $"{mi} -> {limiter}";
 
             GenerateVMD(true);
-
         }
 
         private void RTC_VmdLimiterProfiler_Form_Load(object sender, EventArgs e)

--- a/Source/Frontend/UI/Components/Memory Tools/RTC_VmdNoTool_Form.cs
+++ b/Source/Frontend/UI/Components/Memory Tools/RTC_VmdNoTool_Form.cs
@@ -1,9 +1,9 @@
-﻿using System.Windows.Forms;
-using RTCV.Common;
-using static RTCV.UI.UI_Extensions;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System.Windows.Forms;
+    using RTCV.Common;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_VmdNoTool_Form : ComponentForm, IAutoColorize, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);

--- a/Source/Frontend/UI/Components/Memory Tools/RTC_VmdPool_Form.cs
+++ b/Source/Frontend/UI/Components/Memory Tools/RTC_VmdPool_Form.cs
@@ -1,16 +1,15 @@
-using System;
-using System.Data;
-using System.IO;
-using System.Linq;
-using System.Windows.Forms;
-using System.Xml.Serialization;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using RTCV.Common;
-using static RTCV.UI.UI_Extensions;
-
 namespace RTCV.UI
 {
+    using System;
+    using System.Data;
+    using System.IO;
+    using System.Linq;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+    using RTCV.Common;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_VmdPool_Form : ComponentForm, IAutoColorize, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);
@@ -92,7 +91,7 @@ namespace RTCV.UI
             }
 
             string name = "";
-            string value = vmdName.Trim().Replace("[V]", ""); ;
+            string value = vmdName.Trim().Replace("[V]", "");
             if (UI_Extensions.GetInputBox("BlastLayer to VMD", "Enter the new VMD name:", ref value) == DialogResult.OK)
             {
                 name = value.Trim();
@@ -132,7 +131,7 @@ namespace RTCV.UI
                     bu.SourceDomain = "[V]" + name;
                 }
             }
-            //Go through the stash history and update any references 
+            //Go through the stash history and update any references
             foreach (StashKey sk in S.GET<RTC_StashHistory_Form>().lbStashHistory.Items)
             {
                 foreach (var bu in sk.BlastLayer.Layer)
@@ -172,7 +171,6 @@ namespace RTCV.UI
 
         private void lbLoadedVmdList_SelectedIndexChanged(object sender, EventArgs e)
         {
-
             btnSendToMyVMDs.Enabled = false;
             btnSaveVmd.Enabled = false;
             btnRenameVmd.Enabled = false;
@@ -218,7 +216,6 @@ namespace RTCV.UI
             //display proto here
 
             tbVmdPrototype.Text = DisplayVMD(vmd);
-
         }
 
         private string DisplayVMD(VirtualMemoryDomain vmd)
@@ -227,7 +224,7 @@ namespace RTCV.UI
 
             sb.Append($"===Singles==={Environment.NewLine}");
 
-            foreach(var i in vmd.Proto.AddSingles)
+            foreach (var i in vmd.Proto.AddSingles)
                 sb.Append($"{i.ToHexString()}{Environment.NewLine}");
 
             foreach (var i in vmd.Proto.RemoveSingles)
@@ -310,7 +307,6 @@ namespace RTCV.UI
             };
             if (ofd.ShowDialog() == DialogResult.OK)
             {
-                bool notified = false;
                 //string Filename = ofd.FileName.ToString();
                 foreach (string filename in ofd.FileNames)
                 {
@@ -351,7 +347,6 @@ namespace RTCV.UI
 
             if (lbLoadedVmdList.SelectedItems.Count == 1)
             {
-
                 string vmdName = lbLoadedVmdList.SelectedItem.ToString();
                 VirtualMemoryDomain vmd = MemoryDomains.VmdPool[vmdName];
 
@@ -369,13 +364,11 @@ namespace RTCV.UI
 
                     if (File.Exists(targetPath))
                     {
-
                         var result = MessageBox.Show("This file already exists in your VMDs folder, do you want to overwrite it?", "Overwrite file?", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
                         if (result == DialogResult.No)
                             return;
 
                         File.Delete(targetPath);
-
                     }
 
                     //creates json file for vmd
@@ -383,16 +376,10 @@ namespace RTCV.UI
                     {
                         JsonHelper.Serialize(vmd.Proto, fs);
                     }
-
-
                 }
-
-
-
             }
             else //multiple selected
             {
-
                 foreach (var item in lbLoadedVmdList.SelectedItems)
                 {
                     string vmdName = item.ToString();
@@ -406,21 +393,17 @@ namespace RTCV.UI
 
                     if (File.Exists(itemTargetPath))
                     {
-
                         var result = MessageBox.Show("This file already exists in your VMDs folder, do you want to overwrite it?", "Overwrite file?", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
                         if (result == DialogResult.No)
                             return;
 
                         File.Delete(itemTargetPath);
-
                     }
 
                     using (FileStream fs = File.Open(itemTargetPath, FileMode.Create))
                     {
                         JsonHelper.Serialize(vmd.Proto, fs);
                     }
-
-
                 }
             }
 

--- a/Source/Frontend/UI/Components/Memory Tools/RTC_VmdSimpleGen_Form.cs
+++ b/Source/Frontend/UI/Components/Memory Tools/RTC_VmdSimpleGen_Form.cs
@@ -1,15 +1,15 @@
-﻿using System;
-using System.Data;
-using System.Globalization;
-using System.Linq;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.Common;
-using RTCV.UI.Components.Controls;
-using static RTCV.UI.UI_Extensions;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Data;
+    using System.Globalization;
+    using System.Linq;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.Common;
+    using RTCV.UI.Components.Controls;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_VmdSimpleGen_Form : ComponentForm, IAutoColorize, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);

--- a/Source/Frontend/UI/Components/RTC_Template_Form.cs
+++ b/Source/Frontend/UI/Components/RTC_Template_Form.cs
@@ -1,9 +1,9 @@
-﻿using System.Windows.Forms;
-using RTCV.Common;
-using static RTCV.UI.UI_Extensions;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System.Windows.Forms;
+    using RTCV.Common;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_Template_Form : ComponentForm, IAutoColorize, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);

--- a/Source/Frontend/UI/Components/Settings/RTC_SettingsAbout_Form.cs
+++ b/Source/Frontend/UI/Components/Settings/RTC_SettingsAbout_Form.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.Common;
-using static RTCV.UI.UI_Extensions;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.Common;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_SettingsAbout_Form : ComponentForm, IAutoColorize, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);

--- a/Source/Frontend/UI/Components/Settings/RTC_SettingsCorrupt_Form.cs
+++ b/Source/Frontend/UI/Components/Settings/RTC_SettingsCorrupt_Form.cs
@@ -1,11 +1,11 @@
-using System;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.Common;
-using static RTCV.UI.UI_Extensions;
-
 namespace RTCV.UI
 {
+    using System;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.Common;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_SettingsCorrupt_Form : ComponentForm, IAutoColorize, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);

--- a/Source/Frontend/UI/Components/Settings/RTC_SettingsGeneral_Form.cs
+++ b/Source/Frontend/UI/Components/Settings/RTC_SettingsGeneral_Form.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.Diagnostics;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.Common;
-using static RTCV.UI.UI_Extensions;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Diagnostics;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.Common;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_SettingsGeneral_Form : ComponentForm, IAutoColorize, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);
@@ -21,43 +21,43 @@ namespace RTCV.UI
 
         //todo - rewrite this?
         /*
-		private void btnImportKeyBindings_Click(object sender, EventArgs e)
-		{
-			
-			if (UI_VanguardImplementation.connector.netConn.status != NetworkStatus.CONNECTED)
-			{
-				MessageBox.Show("Can't import keybindings when not connected to Bizhawk!");
-				return;
-			}
+        private void btnImportKeyBindings_Click(object sender, EventArgs e)
+        {
 
-			try
-			{
-				if (CorruptCore.CorruptCore.EmuDir.Contains(Path.DirectorySeparatorChar + "VERSIONS" + Path.DirectorySeparatorChar))
-				{
-					var bizhawkFolder = new DirectoryInfo(CorruptCore.CorruptCore.EmuDir);
-					var LauncherVersFolder = bizhawkFolder.Parent.Parent;
+            if (UI_VanguardImplementation.connector.netConn.status != NetworkStatus.CONNECTED)
+            {
+                MessageBox.Show("Can't import keybindings when not connected to Bizhawk!");
+                return;
+            }
 
-					var versions = LauncherVersFolder.GetDirectories().Reverse().ToArray();
+            try
+            {
+                if (CorruptCore.CorruptCore.EmuDir.Contains(Path.DirectorySeparatorChar + "VERSIONS" + Path.DirectorySeparatorChar))
+                {
+                    var bizhawkFolder = new DirectoryInfo(CorruptCore.CorruptCore.EmuDir);
+                    var LauncherVersFolder = bizhawkFolder.Parent.Parent;
 
-					var prevVersion = versions[1].Name;
+                    var versions = LauncherVersFolder.GetDirectories().Reverse().ToArray();
 
-					var dr = MessageBox.Show(
-						"RTC Launcher detected,\n" +
-						$"Do you want to import Controller/Hotkey bindings from version {prevVersion}"
-						, $"Import config from previous version ?", MessageBoxButtons.YesNo, MessageBoxIcon.Information);
+                    var prevVersion = versions[1].Name;
 
-					if (dr == DialogResult.Yes)
-						Stockpile.LoadBizhawkKeyBindsFromIni(versions[1].FullName + Path.DirectorySeparatorChar + "BizHawk\\config.ini");
-					else
-						Stockpile.LoadBizhawkKeyBindsFromIni();
-				}
-				else
-					Stockpile.LoadBizhawkKeyBindsFromIni();
-			}
-			finally
-			{
-			}
-		}*/
+                    var dr = MessageBox.Show(
+                        "RTC Launcher detected,\n" +
+                        $"Do you want to import Controller/Hotkey bindings from version {prevVersion}"
+                        , $"Import config from previous version ?", MessageBoxButtons.YesNo, MessageBoxIcon.Information);
+
+                    if (dr == DialogResult.Yes)
+                        Stockpile.LoadBizhawkKeyBindsFromIni(versions[1].FullName + Path.DirectorySeparatorChar + "BizHawk\\config.ini");
+                    else
+                        Stockpile.LoadBizhawkKeyBindsFromIni();
+                }
+                else
+                    Stockpile.LoadBizhawkKeyBindsFromIni();
+            }
+            finally
+            {
+            }
+        }*/
 
         private void btnOpenOnlineWiki_Click(object sender, EventArgs e)
         {

--- a/Source/Frontend/UI/Components/Settings/RTC_SettingsHotkeyConfig_Form.cs
+++ b/Source/Frontend/UI/Components/Settings/RTC_SettingsHotkeyConfig_Form.cs
@@ -1,16 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Windows.Forms;
-using Newtonsoft.Json;
-using RTCV.Common;
-using RTCV.UI.Components.Controls;
-using static RTCV.UI.UI_Extensions;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Data;
+    using System.Drawing;
+    using System.Linq;
+    using System.Windows.Forms;
+    using Newtonsoft.Json;
+    using RTCV.Common;
+    using RTCV.UI.Components.Controls;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_SettingsHotkeyConfig_Form : ComponentForm, IAutoColorize, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);

--- a/Source/Frontend/UI/Components/Settings/RTC_SettingsNetCore_Form.cs
+++ b/Source/Frontend/UI/Components/Settings/RTC_SettingsNetCore_Form.cs
@@ -1,14 +1,14 @@
-﻿using System;
-using System.Data;
-using System.IO;
-using System.Linq;
-using System.Media;
-using System.Windows.Forms;
-using RTCV.Common;
-using static RTCV.UI.UI_Extensions;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Data;
+    using System.IO;
+    using System.Linq;
+    using System.Media;
+    using System.Windows.Forms;
+    using RTCV.Common;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_SettingsNetCore_Form : ComponentForm, IAutoColorize, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);

--- a/Source/Frontend/UI/Forms/RTC_AnalyticsTool_Form.cs
+++ b/Source/Frontend/UI/Forms/RTC_AnalyticsTool_Form.cs
@@ -1,19 +1,15 @@
-using System;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using RTCV.Common;
-using System.Collections.Generic;
-using System.IO;
-using System.Dynamic;
-using System.Runtime.Serialization.Formatters;
-using System.Threading.Tasks;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Threading;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Windows.Forms;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Threading.Tasks;
+    using System.Linq;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+    using RTCV.Common;
+
     public partial class RTC_AnalyticsTool_Form : Form, IAutoColorize
     {
         public BlastLayer originalBlastLayer = null;
@@ -56,9 +52,9 @@ namespace RTCV.UI
             foreach (var dump in memoryDumpPaths)
             {
                 var fi = new FileInfo(dump);
-                stf.DumpSource.Add(new { 
-                    key = fi.Name, 
-                    value = fi.FullName 
+                stf.DumpSource.Add(new {
+                    key = fi.Name,
+                    value = fi.FullName
                 });
             }
 
@@ -164,11 +160,9 @@ namespace RTCV.UI
                 {
                     dumpSize = dump.Length;
                     nbWords = (dumpSize / WordSize);
-
                 }
 
                 AnalyticsCube.Push(dump, WordSize);
-
             }
 
             var cpus = Environment.ProcessorCount;
@@ -206,7 +200,6 @@ namespace RTCV.UI
                     }
 
                     return (real_i, activity.ToArray(), maxActivity);
-
                 }, state: i);
 
                 tasks.Add(task);
@@ -215,11 +208,11 @@ namespace RTCV.UI
 
             Task.WaitAll(tasks.ToArray());
             var returns = tasks.Select(it => (it as Task<(int cpu_i, int[] activity, int maxActivity)>).Result).OrderBy(it => it.cpu_i).ToArray();
-            
+
             int maxActivity = 0;
             List<int> fullActivity = new List<int>();
 
-            foreach(var ret in returns)
+            foreach (var ret in returns)
             {
                 if (maxActivity < ret.maxActivity)
                     maxActivity = ret.maxActivity;
@@ -256,7 +249,7 @@ namespace RTCV.UI
         {
             int activity = 0;
 
-            for(int i=0;i<stripe.Count;i++)
+            for (int i=0; i<stripe.Count; i++)
             {
                 if (i == 0)
                     continue;
@@ -266,7 +259,7 @@ namespace RTCV.UI
                 byte[] prevWord = stripe[i - 1];
                 byte[] currentWord = stripe[i];
 
-                for (int j=0;j< currentWord.Length; j++)
+                for (int j=0; j< currentWord.Length; j++)
                 {
                     if (prevWord[j] != currentWord[j])
                     {
@@ -288,7 +281,8 @@ namespace RTCV.UI
             {
                 return Cube[x][y];
             }
-            catch(Exception ex)
+            #pragma warning disable CS0168
+            catch (Exception ex)
             {
                 new object();
                 return null;
@@ -320,11 +314,10 @@ namespace RTCV.UI
         {
             byte[] output = new byte[wordSize];
 
-            for(int i=0;i<wordSize;i++)
+            for (int i=0; i < wordSize; i++)
                 output[i] = dump[index + i];
 
             return output;
         }
     }
-
 }

--- a/Source/Frontend/UI/Forms/RTC_BlastGenerator_Form.cs
+++ b/Source/Frontend/UI/Forms/RTC_BlastGenerator_Form.cs
@@ -1,16 +1,16 @@
-using System;
-using System.Collections.Generic;
-using System.Data;
-using System.IO;
-using System.Linq;
-using System.Windows.Forms;
-using Newtonsoft.Json;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using RTCV.Common;
-
 namespace RTCV.UI
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Data;
+    using System.IO;
+    using System.Linq;
+    using System.Windows.Forms;
+    using Newtonsoft.Json;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+    using RTCV.Common;
+
     // 0  dgvBlastProtoReference
     // 1  dgvRowDirty
     // 2  dgvEnabled
@@ -69,7 +69,7 @@ namespace RTCV.UI
         {
             InitializeComponent();
 
-            //For some godforsaken reason, xmlSerializer deserialization wont fill this in as a bool so just use a string god help us all 
+            //For some godforsaken reason, xmlSerializer deserialization wont fill this in as a bool so just use a string god help us all
             (dgvBlastGenerator.Columns["dgvEnabled"]).ValueType = typeof(string);
         }
 
@@ -146,7 +146,7 @@ namespace RTCV.UI
                 //Set up the DGV based on the current state of Bizhawk
                 (dgvBlastGenerator.Rows[lastrow].Cells["dgvRowDirty"]).Value = true;
 
-                //For some godforsaken reason, xmlSerializer deserialization wont fill this in as a bool so just use a string god help us all 
+                //For some godforsaken reason, xmlSerializer deserialization wont fill this in as a bool so just use a string god help us all
                 (dgvBlastGenerator.Rows[lastrow].Cells["dgvEnabled"]).ValueType = typeof(string);
                 ((DataGridViewCheckBoxCell)(dgvBlastGenerator.Rows[lastrow].Cells["dgvEnabled"])).TrueValue = "true";
                 ((DataGridViewCheckBoxCell)(dgvBlastGenerator.Rows[lastrow].Cells["dgvEnabled"])).FalseValue = "false";
@@ -880,7 +880,7 @@ namespace RTCV.UI
                     DataTable dt = null;
                     var settings = new JsonSerializerSettings
                     {
-                        //	NullValueHandling = NullValueHandling.Ignore,
+                        //    NullValueHandling = NullValueHandling.Ignore,
                     };
                     dt = JsonConvert.DeserializeObject<DataTable>(File.ReadAllText(ofd.FileName), settings);
                     if (!import)

--- a/Source/Frontend/UI/Forms/RTC_ConnectionStatus_Form.cs
+++ b/Source/Frontend/UI/Forms/RTC_ConnectionStatus_Form.cs
@@ -1,11 +1,11 @@
-using System;
-using System.Drawing;
-using System.Windows.Forms;
-using RTCV.Common;
-using static RTCV.UI.UI_Extensions;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Drawing;
+    using System.Windows.Forms;
+    using RTCV.Common;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_ConnectionStatus_Form : ComponentForm, IAutoColorize, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);

--- a/Source/Frontend/UI/Forms/RTC_CustomEngineConfig_Form.cs
+++ b/Source/Frontend/UI/Forms/RTC_CustomEngineConfig_Form.cs
@@ -1,13 +1,13 @@
-﻿using System;
-using System.Drawing;
-using System.Numerics;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using RTCV.Common;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Drawing;
+    using System.Numerics;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+    using RTCV.Common;
+
     public partial class RTC_CustomEngineConfig_Form : Form, IAutoColorize
     {
         private bool updatingMinMax = false;

--- a/Source/Frontend/UI/Forms/RTC_Intro_Form.cs
+++ b/Source/Frontend/UI/Forms/RTC_Intro_Form.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Windows.Forms;
-using RTCV.NetCore;
-using RTCV.Common;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Windows.Forms;
+    using RTCV.NetCore;
+    using RTCV.Common;
+
     public partial class RTC_Intro_Form : Form, IAutoColorize
     {
         public IntroAction selection = IntroAction.EXIT;

--- a/Source/Frontend/UI/Forms/RTC_NewBlastEditor_Form.cs
+++ b/Source/Frontend/UI/Forms/RTC_NewBlastEditor_Form.cs
@@ -1,16 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.IO;
-using System.Linq;
-using System.Numerics;
-using System.Text;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using RTCV.Common;
-
 /**
  * The DataGridView is bound to the blastlayer
  * All validation is done within the dgv
@@ -20,32 +7,32 @@ using RTCV.Common;
 
 /*
 Applies in all cases & should be editable
- * bool IsEnabled 
+ * bool IsEnabled
  * bool IsLocked
- * 
- * string Domain 
- * long Address 
- * int Precision 
- * BlastUnitSource Source 
-
- * BigInteger TiltValue 
- * 
- * int ExecuteFrame 
- * int Lifetime 
- * bool Loop 
- * 
- * ActionTime LimiterTime 
- * string LimiterListHash 
- * bool InvertLimiter 
  *
- * string Note 
+ * string Domain
+ * long Address
+ * int Precision
+ * BlastUnitSource Source
+
+ * BigInteger TiltValue
+ *
+ * int ExecuteFrame
+ * int Lifetime
+ * bool Loop
+ *
+ * ActionTime LimiterTime
+ * string LimiterListHash
+ * bool InvertLimiter
+ *
+ * string Note
 
 
 Applies for Store & should be editable
- * ActionTime StoreTime 
- * StoreType StoreType 
- * string SourceDomain 
- * long SourceAddress 
+ * ActionTime StoreTime
+ * StoreType StoreType
+ * string SourceDomain
+ * long SourceAddress
 
 
 Applies for Value & should be editable
@@ -53,6 +40,19 @@ Applies for Value & should be editable
 
 namespace RTCV.UI
 {
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Data;
+    using System.IO;
+    using System.Linq;
+    using System.Numerics;
+    using System.Text;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+    using RTCV.Common;
+
     public partial class RTC_NewBlastEditor_Form : Form, IAutoColorize
     {
         private static Dictionary<string, MemoryInterface> _domainToMiDico;
@@ -101,7 +101,7 @@ namespace RTCV.UI
             Note
         }
         //We gotta cache this stuff outside of the scope of InitializeDGV
-        //	private object actionTimeValues = 
+        //    private object actionTimeValues =
 
         public RTC_NewBlastEditor_Form()
         {
@@ -609,7 +609,6 @@ namespace RTCV.UI
 
         private void UpDownLoopTiming_Validated(object sender, EventArgs e)
         {
-
             var value = upDownLoopTiming.Value;
             if (value > int.MaxValue)
             {
@@ -814,25 +813,25 @@ namespace RTCV.UI
                 var lastRow = dgvBlastEditor.SelectedRows[dgvBlastEditor.SelectedRows.Count - 1];
 
                 /*
-				cbDomain.SelectedItem = (String)(lastRow.Cells[buProperty.Domain.ToString()].Value);
-				cbEnabled.Checked = (bool)(lastRow.Cells[buProperty.isEnabled.ToString()].Value);
-				cbLocked.Checked = (bool)(lastRow.Cells[buProperty.isLocked.ToString()].Value);
-				upDownAddress.Value = (long)(lastRow.Cells[buProperty.Address.ToString()].Value);
-				upDownPrecision.Value = (int)(lastRow.Cells[buProperty.Precision.ToString()].Value);
-				tbValue.Text = (String)(lastRow.Cells[buProperty.ValueString.ToString()].Value);
-				upDownExecuteFrame.Value = (int)(lastRow.Cells[buProperty.ExecuteFrame.ToString()].Value);
-				upDownLifetime.Value = (int)(lastRow.Cells[buProperty.Lifetime.ToString()].Value);
-				cbLoop.Checked = (bool)(lastRow.Cells[buProperty.Loop.ToString()].Value);
-				cbLimiterTime.SelectedItem = (ActionTime)(lastRow.Cells[buProperty.LimiterTime.ToString()].Value);
-				cbLimiterList.SelectedItem = (String)(lastRow.Cells[buProperty.LimiterHash.ToString()].Value);
-				cbInvertLimiter.Checked = (bool)(lastRow.Cells[buProperty.InvertLimiter.ToString()].Value);
-				cbStoreTime.SelectedItem = (ActionTime)(lastRow.Cells[buProperty.StoreTime.ToString()].Value);
-				cbStoreType.SelectedItem = (StoreType)(lastRow.Cells[buProperty.StoreType.ToString()].Value);
-				cbSourceDomain.SelectedItem = (String)(lastRow.Cells[buProperty.SourceDomain.ToString()].Value);
-				cbSource.SelectedItem = (BlastUnitSource)(lastRow.Cells[buProperty.Source.ToString()].Value);
-				upDownSourceAddress.Value = (long)(lastRow.Cells[buProperty.SourceAddress.ToString()].Value);
+                cbDomain.SelectedItem = (String)(lastRow.Cells[buProperty.Domain.ToString()].Value);
+                cbEnabled.Checked = (bool)(lastRow.Cells[buProperty.isEnabled.ToString()].Value);
+                cbLocked.Checked = (bool)(lastRow.Cells[buProperty.isLocked.ToString()].Value);
+                upDownAddress.Value = (long)(lastRow.Cells[buProperty.Address.ToString()].Value);
+                upDownPrecision.Value = (int)(lastRow.Cells[buProperty.Precision.ToString()].Value);
+                tbValue.Text = (String)(lastRow.Cells[buProperty.ValueString.ToString()].Value);
+                upDownExecuteFrame.Value = (int)(lastRow.Cells[buProperty.ExecuteFrame.ToString()].Value);
+                upDownLifetime.Value = (int)(lastRow.Cells[buProperty.Lifetime.ToString()].Value);
+                cbLoop.Checked = (bool)(lastRow.Cells[buProperty.Loop.ToString()].Value);
+                cbLimiterTime.SelectedItem = (ActionTime)(lastRow.Cells[buProperty.LimiterTime.ToString()].Value);
+                cbLimiterList.SelectedItem = (String)(lastRow.Cells[buProperty.LimiterHash.ToString()].Value);
+                cbInvertLimiter.Checked = (bool)(lastRow.Cells[buProperty.InvertLimiter.ToString()].Value);
+                cbStoreTime.SelectedItem = (ActionTime)(lastRow.Cells[buProperty.StoreTime.ToString()].Value);
+                cbStoreType.SelectedItem = (StoreType)(lastRow.Cells[buProperty.StoreType.ToString()].Value);
+                cbSourceDomain.SelectedItem = (String)(lastRow.Cells[buProperty.SourceDomain.ToString()].Value);
+                cbSource.SelectedItem = (BlastUnitSource)(lastRow.Cells[buProperty.Source.ToString()].Value);
+                upDownSourceAddress.Value = (long)(lastRow.Cells[buProperty.SourceAddress.ToString()].Value);
 
-				tbTiltValue.Text = (lastRow.DataBoundItem as BlastUnit).TiltValue.ToString();*/
+                tbTiltValue.Text = (lastRow.DataBoundItem as BlastUnit).TiltValue.ToString();*/
                 BlastUnit bu = (BlastUnit)lastRow.DataBoundItem;
 
                 if (DomainToMiDico.ContainsKey(bu.Domain ?? string.Empty))
@@ -1237,11 +1236,11 @@ namespace RTCV.UI
         }
 
         /*
-		private DataGridViewColumn CreateColumnUnbound(string columnName, string displayName,
-			DataGridViewColumn column, int fillWeight = -1)
-		{
-			return CreateColumn(String.Empty, columnName, displayName, column, fillWeight);
-		}
+        private DataGridViewColumn CreateColumnUnbound(string columnName, string displayName,
+            DataGridViewColumn column, int fillWeight = -1)
+        {
+            return CreateColumn(String.Empty, columnName, displayName, column, fillWeight);
+        }
         */
 
         private StashKey originalSK = null;
@@ -1806,7 +1805,7 @@ namespace RTCV.UI
         private void loadFromFileblToolStripMenuItem_Click(object sender, EventArgs e)
         {
             BlastLayer temp = BlastTools.LoadBlastLayerFromFile();
-            if(temp != null)
+            if (temp != null)
                 LoadBlastlayer(temp);
         }
 
@@ -2181,7 +2180,6 @@ namespace RTCV.UI
                 lastAnswer = MessageBox.Show(@"Is the effect you are looking for still present?", "BlastLayer sanitization", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question);
             }
             */
-
         }
 
         public StashKey[] GetStashKeys()

--- a/Source/Frontend/UI/Forms/RTC_NoteEditor_Form.cs
+++ b/Source/Frontend/UI/Forms/RTC_NoteEditor_Form.cs
@@ -1,14 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.Common;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Data;
+    using System.Drawing;
+    using System.Linq;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.Common;
+
     public partial class RTC_NoteEditor_Form : Form
     {
         private INote note;

--- a/Source/Frontend/UI/Forms/RTC_Settings_Form.cs
+++ b/Source/Frontend/UI/Forms/RTC_Settings_Form.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.Diagnostics;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.Common;
-using static RTCV.UI.UI_Extensions;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Diagnostics;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.Common;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_Settings_Form : ComponentForm, IAutoColorize, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);
@@ -18,7 +18,7 @@ namespace RTCV.UI
         {
             InitializeComponent();
 
-            lbForm = new RTC_ListBox_Form(new ComponentForm[]{
+            lbForm = new RTC_ListBox_Form(new ComponentForm[] {
                 S.GET<RTC_SettingsGeneral_Form>(),
                 S.GET<RTC_SettingsCorrupt_Form>(),
                 S.GET<RTC_SettingsHotkeyConfig_Form>(),
@@ -52,10 +52,10 @@ namespace RTCV.UI
         {
             //If we're not connected, go to connectionstatus
             /*
-			if (UI_VanguardImplementation.connector.netConn.status != NetCore.NetworkStatus.CONNECTED)
-				S.GET<RTC_Core_Form>().ShowPanelForm(S.GET<RTC_ConnectionStatus_Form>());
-			else
-				S.GET<RTC_Core_Form>().ShowPanelForm(S.GET<RTC_Core_Form>().previousForm, false);
+            if (UI_VanguardImplementation.connector.netConn.status != NetCore.NetworkStatus.CONNECTED)
+                S.GET<RTC_Core_Form>().ShowPanelForm(S.GET<RTC_ConnectionStatus_Form>());
+            else
+                S.GET<RTC_Core_Form>().ShowPanelForm(S.GET<RTC_Core_Form>().previousForm, false);
              */
 
             MessageBox.Show("is this even needed anymore?");

--- a/Source/Frontend/UI/Forms/RTC_SimpleMode_Form.cs
+++ b/Source/Frontend/UI/Forms/RTC_SimpleMode_Form.cs
@@ -1,14 +1,14 @@
-﻿using System;
-using System.Drawing;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using RTCV.Common;
-using RTCV.UI.Components.Controls;
-using static RTCV.UI.UI_Extensions;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Drawing;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+    using RTCV.Common;
+    using RTCV.UI.Components.Controls;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_SimpleMode_Form : ComponentForm, IAutoColorize, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);

--- a/Source/Frontend/UI/Forms/RTC_StockpilePlayer_Form.cs
+++ b/Source/Frontend/UI/Forms/RTC_StockpilePlayer_Form.cs
@@ -1,17 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using RTCV.Common;
-using static RTCV.UI.UI_Extensions;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Drawing;
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+    using RTCV.Common;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class RTC_StockpilePlayer_Form : ComponentForm, IAutoColorize, IBlockable
     {
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);
@@ -196,7 +196,7 @@ namespace RTCV.UI
         {
             try
             {
-                //We do this here and invoke because our unlock runs at the end of the awaited method, but there's a chance an error occurs 
+                //We do this here and invoke because our unlock runs at the end of the awaited method, but there's a chance an error occurs
                 //Thus, we want this to happen within the try block
                 UICore.SetHotkeyTimer(false);
                 UICore.LockInterface(false, true);

--- a/Source/Frontend/UI/Forms/RTC_StockpilePlayer_Form.designer.cs
+++ b/Source/Frontend/UI/Forms/RTC_StockpilePlayer_Form.designer.cs
@@ -1,7 +1,7 @@
-using System.Windows.Forms;
-
 namespace RTCV.UI
 {
+    using System.Windows.Forms;
+
     partial class RTC_StockpilePlayer_Form
     {
         /// <summary>
@@ -52,9 +52,9 @@ namespace RTCV.UI
             this.label2 = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.dgvStockpile)).BeginInit();
             this.SuspendLayout();
-            // 
+            //
             // btnNextItem
-            // 
+            //
             this.btnNextItem.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.btnNextItem.BackColor = System.Drawing.Color.LightGreen;
             this.btnNextItem.FlatAppearance.BorderSize = 0;
@@ -68,9 +68,9 @@ namespace RTCV.UI
             this.btnNextItem.Text = "Next";
             this.btnNextItem.UseVisualStyleBackColor = false;
             this.btnNextItem.Click += new System.EventHandler(this.btnNextItem_Click);
-            // 
+            //
             // btnReloadItem
-            // 
+            //
             this.btnReloadItem.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.btnReloadItem.BackColor = System.Drawing.Color.LightGreen;
             this.btnReloadItem.FlatAppearance.BorderSize = 0;
@@ -83,9 +83,9 @@ namespace RTCV.UI
             this.btnReloadItem.TabIndex = 126;
             this.btnReloadItem.UseVisualStyleBackColor = false;
             this.btnReloadItem.Click += new System.EventHandler(this.btnReloadItem_Click);
-            // 
+            //
             // btnPreviousItem
-            // 
+            //
             this.btnPreviousItem.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.btnPreviousItem.BackColor = System.Drawing.Color.LightGreen;
             this.btnPreviousItem.FlatAppearance.BorderSize = 0;
@@ -99,9 +99,9 @@ namespace RTCV.UI
             this.btnPreviousItem.Text = "Previous";
             this.btnPreviousItem.UseVisualStyleBackColor = false;
             this.btnPreviousItem.Click += new System.EventHandler(this.btnPreviousItem_Click);
-            // 
+            //
             // btnLoadStockpile
-            // 
+            //
             this.btnLoadStockpile.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.btnLoadStockpile.BackColor = System.Drawing.Color.Orange;
             this.btnLoadStockpile.FlatAppearance.BorderSize = 0;
@@ -115,10 +115,10 @@ namespace RTCV.UI
             this.btnLoadStockpile.Text = "Load";
             this.btnLoadStockpile.UseVisualStyleBackColor = false;
             this.btnLoadStockpile.MouseDown += new System.Windows.Forms.MouseEventHandler(this.btnLoadStockpile_MouseDown);
-            // 
+            //
             // btnBlastToggle
-            // 
-            this.btnBlastToggle.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            //
+            this.btnBlastToggle.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.btnBlastToggle.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(32)))), ((int)(((byte)(32)))), ((int)(((byte)(32)))));
             this.btnBlastToggle.FlatAppearance.BorderSize = 0;
@@ -134,15 +134,15 @@ namespace RTCV.UI
             this.btnBlastToggle.Text = "BlastLayer : OFF    (Attempts to uncorrupt/recorrupt in real-time)";
             this.btnBlastToggle.UseVisualStyleBackColor = false;
             this.btnBlastToggle.Click += new System.EventHandler(this.btnBlastToggle_Click);
-            // 
+            //
             // dgvStockpile
-            // 
+            //
             this.dgvStockpile.AllowDrop = true;
             this.dgvStockpile.AllowUserToAddRows = false;
             this.dgvStockpile.AllowUserToDeleteRows = false;
             this.dgvStockpile.AllowUserToResizeRows = false;
-            this.dgvStockpile.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
+            this.dgvStockpile.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.dgvStockpile.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
             this.dgvStockpile.BackgroundColor = System.Drawing.Color.Gray;
@@ -178,35 +178,35 @@ namespace RTCV.UI
             this.dgvStockpile.Tag = "color:normal";
             this.dgvStockpile.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dgvStockpile_CellClick);
             this.dgvStockpile.MouseDown += new System.Windows.Forms.MouseEventHandler(this.dgvStockpile_MouseDown);
-            // 
+            //
             // Item
-            // 
+            //
             this.Item.HeaderText = "Item Name";
             this.Item.Name = "Item";
             this.Item.ReadOnly = true;
-            // 
+            //
             // GameName
-            // 
+            //
             this.GameName.FillWeight = 45F;
             this.GameName.HeaderText = "Game";
             this.GameName.Name = "GameName";
             this.GameName.ReadOnly = true;
-            // 
+            //
             // SystemName
-            // 
+            //
             this.SystemName.FillWeight = 45F;
             this.SystemName.HeaderText = "System";
             this.SystemName.Name = "SystemName";
             this.SystemName.ReadOnly = true;
-            // 
+            //
             // SystemCore
-            // 
+            //
             this.SystemCore.FillWeight = 40F;
             this.SystemCore.HeaderText = "Core";
             this.SystemCore.Name = "SystemCore";
-            // 
+            //
             // Note
-            // 
+            //
             dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
             dataGridViewCellStyle1.Font = new System.Drawing.Font("Segoe UI", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             dataGridViewCellStyle1.ForeColor = System.Drawing.Color.Black;
@@ -217,10 +217,10 @@ namespace RTCV.UI
             this.Note.Name = "Note";
             this.Note.Resizable = System.Windows.Forms.DataGridViewTriState.True;
             this.Note.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            // 
+            //
             // tbNoteBox
-            // 
-            this.tbNoteBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            //
+            this.tbNoteBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.tbNoteBox.BackColor = System.Drawing.Color.Gray;
             this.tbNoteBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
@@ -234,39 +234,39 @@ namespace RTCV.UI
             this.tbNoteBox.TabIndex = 143;
             this.tbNoteBox.Tag = "color:normal";
             this.tbNoteBox.Text = "Notes will appear here...";
-            // 
+            //
             // dataGridViewTextBoxColumn1
-            // 
+            //
             this.dataGridViewTextBoxColumn1.HeaderText = "Item Name";
             this.dataGridViewTextBoxColumn1.Name = "dataGridViewTextBoxColumn1";
             this.dataGridViewTextBoxColumn1.ReadOnly = true;
             this.dataGridViewTextBoxColumn1.Width = 238;
-            // 
+            //
             // dataGridViewTextBoxColumn2
-            // 
+            //
             this.dataGridViewTextBoxColumn2.FillWeight = 45F;
             this.dataGridViewTextBoxColumn2.HeaderText = "Game";
             this.dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
             this.dataGridViewTextBoxColumn2.ReadOnly = true;
             this.dataGridViewTextBoxColumn2.Width = 113;
-            // 
+            //
             // dataGridViewTextBoxColumn3
-            // 
+            //
             this.dataGridViewTextBoxColumn3.FillWeight = 45F;
             this.dataGridViewTextBoxColumn3.HeaderText = "System";
             this.dataGridViewTextBoxColumn3.Name = "dataGridViewTextBoxColumn3";
             this.dataGridViewTextBoxColumn3.ReadOnly = true;
             this.dataGridViewTextBoxColumn3.Width = 112;
-            // 
+            //
             // dataGridViewTextBoxColumn4
-            // 
+            //
             this.dataGridViewTextBoxColumn4.FillWeight = 40F;
             this.dataGridViewTextBoxColumn4.HeaderText = "Core";
             this.dataGridViewTextBoxColumn4.Name = "dataGridViewTextBoxColumn4";
             this.dataGridViewTextBoxColumn4.Width = 101;
-            // 
+            //
             // label2
-            // 
+            //
             this.label2.AutoSize = true;
             this.label2.Font = new System.Drawing.Font("Segoe UI Semibold", 22F, System.Drawing.FontStyle.Bold);
             this.label2.ForeColor = System.Drawing.Color.White;
@@ -275,9 +275,9 @@ namespace RTCV.UI
             this.label2.Size = new System.Drawing.Size(234, 41);
             this.label2.TabIndex = 83;
             this.label2.Text = "Stockpile Player";
-            // 
+            //
             // RTC_StockpilePlayer_Form
-            // 
+            //
             this.AllowDrop = true;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;

--- a/Source/Frontend/UI/Forms/RTC_Test_Form.cs
+++ b/Source/Frontend/UI/Forms/RTC_Test_Form.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Windows.Forms;
-using RTCV.Common;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Windows.Forms;
+    using RTCV.Common;
+
     public partial class RTC_Test_Form : Form, IAutoColorize
     {
         public RTC_Test_Form()

--- a/Source/Frontend/UI/GameProtection.cs
+++ b/Source/Frontend/UI/GameProtection.cs
@@ -1,14 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+
     //Todo, rebuild this?
     public static class GameProtection
     {

--- a/Source/Frontend/UI/Input/Bindings.cs
+++ b/Source/Frontend/UI/Input/Bindings.cs
@@ -1,10 +1,10 @@
 ﻿//Based on code from https://github.com/TASVideos/BizHawk/
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-
 namespace RTCV.UI.Input
 {
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+
     public static class Bindings
     {
         private static readonly WorkingDictionary<string, List<string>> _bindings = new WorkingDictionary<string, List<string>>();

--- a/Source/Frontend/UI/Input/Gamepad.cs
+++ b/Source/Frontend/UI/Input/Gamepad.cs
@@ -2,14 +2,14 @@
 //https://github.com/tasvideos/bizhawk
 //Thanks guys
 
-using System;
-using System.Collections.Generic;
-using RTCV.Common;
-using SlimDX;
-using SlimDX.DirectInput;
-
 namespace RTCV.UI.Input
 {
+    using System;
+    using System.Collections.Generic;
+    using RTCV.Common;
+    using SlimDX;
+    using SlimDX.DirectInput;
+
     public class GamePad
     {
         // ********************************** Static interface **********************************

--- a/Source/Frontend/UI/Input/Gamepad360.cs
+++ b/Source/Frontend/UI/Input/Gamepad360.cs
@@ -2,17 +2,17 @@
 //https://github.com/tasvideos/bizhawk
 //Thanks guys
 
-using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using RTCV.CorruptCore;
-using SlimDX.XInput;
-
 #pragma warning disable 169
 #pragma warning disable 414
 
 namespace RTCV.UI.Input
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Runtime.InteropServices;
+    using RTCV.CorruptCore;
+    using SlimDX.XInput;
+
     public class GamePad360
     {
         // ********************************** Static interface **********************************

--- a/Source/Frontend/UI/Input/IPCKeyInput.cs
+++ b/Source/Frontend/UI/Input/IPCKeyInput.cs
@@ -2,16 +2,14 @@
 //https://github.com/tasvideos/bizhawk
 //Thanks guys
 
-using System.Collections.Generic;
-using System.IO;
-using System.IO.Pipes;
-using System.Threading;
-using SlimDX.DirectInput;
-
-//Lifted from bizhawk
-
 namespace RTCV.UI.Input
 {
+    using System.Collections.Generic;
+    using System.IO;
+    using System.IO.Pipes;
+    using System.Threading;
+    using SlimDX.DirectInput;
+
     public static class IPCKeyInput
     {
         public static void Initialize()

--- a/Source/Frontend/UI/Input/Input.cs
+++ b/Source/Frontend/UI/Input/Input.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading;
-using RTCV.NetCore;
-
-namespace RTCV.UI.Input
+﻿namespace RTCV.UI.Input
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using RTCV.NetCore;
+
     public class Input
     {
         [Flags]
@@ -171,7 +171,7 @@ namespace RTCV.UI.Input
             if (LastState[button] && newState) return;
             if (!LastState[button] && !newState) return;
 
-            //apply 
+            //apply
             //NOTE: this is not quite right. if someone held leftshift+rightshift it would be broken. seems unlikely, though.
             if (button == "LeftShift")
             {
@@ -333,7 +333,7 @@ namespace RTCV.UI.Input
                                 string n = jname + sv.Item1;
                                 float f = sv.Item2;
                                 //if (n == "J5 RotationZ")
-                                //	System.Diagnostics.Debugger.Break();
+                                //    System.Diagnostics.Debugger.Break();
                                 if (trackdeltas)
                                     FloatDeltas[n] += Math.Abs(f - FloatValues[n]);
                                 FloatValues[n] = f;

--- a/Source/Frontend/UI/Input/Keyboard.cs
+++ b/Source/Frontend/UI/Input/Keyboard.cs
@@ -2,13 +2,13 @@
 //https://github.com/tasvideos/bizhawk
 //Thanks guys
 
-using System.Collections.Generic;
-using RTCV.Common;
-using SlimDX;
-using SlimDX.DirectInput;
-
 namespace RTCV.UI.Input
 {
+    using System.Collections.Generic;
+    using RTCV.Common;
+    using SlimDX;
+    using SlimDX.DirectInput;
+
     public static class KeyInput
     {
         private static readonly object _syncObj = new object();

--- a/Source/Frontend/UI/Modular/UI_CanvasForm.cs
+++ b/Source/Frontend/UI/Modular/UI_CanvasForm.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Windows.Forms;
-using RTCV.Common;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Drawing;
+    using System.Windows.Forms;
+    using RTCV.Common;
+
     public partial class UI_CanvasForm : Form, IBlockable
     {
         public static UI_CanvasForm mainForm;

--- a/Source/Frontend/UI/Modular/UI_ComponentFormSubForm.cs
+++ b/Source/Frontend/UI/Modular/UI_ComponentFormSubForm.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using static RTCV.UI.UI_Extensions;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class UI_ComponentFormSubForm : ComponentForm, ISubForm, IBlockable
     {
         public UI_ComponentFormSubForm()

--- a/Source/Frontend/UI/Modular/UI_ComponentFormTile.cs
+++ b/Source/Frontend/UI/Modular/UI_ComponentFormTile.cs
@@ -1,9 +1,9 @@
-﻿using System.Drawing;
-using System.Windows.Forms;
-using static RTCV.UI.UI_Extensions;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System.Drawing;
+    using System.Windows.Forms;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class UI_ComponentFormTile : Form, ITileForm
     {
         public Form childForm = null;

--- a/Source/Frontend/UI/Modular/UI_CoreForm.cs
+++ b/Source/Frontend/UI/Modular/UI_CoreForm.cs
@@ -1,16 +1,16 @@
-using System;
-using System.Diagnostics;
-using System.Drawing;
-using System.IO;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using RTCV.Common;
-using RTCV.UI.Modular;
-using System.Linq;
-
 namespace RTCV.UI
 {
+    using System;
+    using System.Diagnostics;
+    using System.Drawing;
+    using System.IO;
+    using System.Linq;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+    using RTCV.Common;
+    using RTCV.UI.Modular;
+
     public partial class UI_CoreForm : Form, IAutoColorize
     {
         //This form traps events and forwards them.
@@ -178,7 +178,7 @@ This message only appears once.";
 
         private void UI_CoreForm_ResizeBegin(object sender, EventArgs e)
         {
-            //Sends event to SubForm 
+            //Sends event to SubForm
             if (cfForm.spForm != null)
             {
                 cfForm.spForm.Parent_ResizeBegin();
@@ -464,7 +464,7 @@ This message only appears once.";
                 btnGpJumpNow.Visible = false;
 
                 //Do this to prevent any potential race
-                var sk = StockpileManager_UISide.BackupedState; ;
+                var sk = StockpileManager_UISide.BackupedState;
 
                 if (sk != null)
                 {
@@ -491,7 +491,7 @@ This message only appears once.";
 
         public void StartEasyMode(bool useTemplate)
         {
-            //	if (RTC_NetcoreImplementation.isStandaloneUI && !S.GET<RTC_Core_Form>().cbUseGameProtection.Checked)
+            //if (RTC_NetcoreImplementation.isStandaloneUI && !S.GET<RTC_Core_Form>().cbUseGameProtection.Checked)
             S.GET<UI_CoreForm>().cbUseGameProtection.Checked = true;
 
             if (useTemplate)

--- a/Source/Frontend/UI/Modular/UI_DefaultGrids.cs
+++ b/Source/Frontend/UI/Modular/UI_DefaultGrids.cs
@@ -1,9 +1,9 @@
-using System.Windows.Forms;
-using RTCV.Common;
-using static RTCV.UI.UI_Extensions;
-
 namespace RTCV.UI.Modular
 {
+    using System.Windows.Forms;
+    using RTCV.Common;
+    using static RTCV.UI.UI_Extensions;
+
     public static class UI_DefaultGrids
     {
         private static CanvasGrid _connectionStatus = null;

--- a/Source/Frontend/UI/Modular/UI_Objects.cs
+++ b/Source/Frontend/UI/Modular/UI_Objects.cs
@@ -1,11 +1,11 @@
-using System;
-using System.Drawing;
-using System.IO;
-using System.Windows.Forms;
-using RTCV.Common;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Drawing;
+    using System.IO;
+    using System.Windows.Forms;
+    using RTCV.Common;
+
     public interface ISubForm
     {
         //Interface used for added contrals in SubForms
@@ -205,5 +205,3 @@ namespace RTCV.UI
         }
     }
 }
-
-

--- a/Source/Frontend/UI/Modular/UI_SaveProgress_Form.cs
+++ b/Source/Frontend/UI/Modular/UI_SaveProgress_Form.cs
@@ -1,11 +1,11 @@
-using System;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using RTCV.Common;
-using static RTCV.UI.UI_Extensions;
-
 namespace RTCV.UI
 {
+    using System;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+    using RTCV.Common;
+    using static RTCV.UI.UI_Extensions;
+
     public partial class UI_SaveProgress_Form : ComponentForm, IAutoColorize, ISubForm
     {
         public UI_SaveProgress_Form()

--- a/Source/Frontend/UI/Modular/UI_ShadowPanel.cs
+++ b/Source/Frontend/UI/Modular/UI_ShadowPanel.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Drawing;
-using System.Windows.Forms;
-
-namespace RTCV.UI
+﻿namespace RTCV.UI
 {
+    using System;
+    using System.Drawing;
+    using System.Windows.Forms;
+
     public partial class UI_ShadowPanel : Form
     {
         public UI_CanvasForm parentForm;

--- a/Source/Frontend/UI/UI.csproj
+++ b/Source/Frontend/UI/UI.csproj
@@ -13,6 +13,7 @@
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />
+    <CodeAnalysisRuleSet>..\..\..\StyleCop.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -48,7 +49,6 @@
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
@@ -59,8 +59,11 @@
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <!-- https://stackoverflow.com/a/12672514 -->
+    <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/Source/Frontend/UI/UIConnector.cs
+++ b/Source/Frontend/UI/UIConnector.cs
@@ -1,12 +1,12 @@
-using System;
-using System.Linq;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using RTCV.Common;
-using RTCV.UI.Modular;
-
 namespace RTCV.UI
 {
+    using System;
+    using System.Linq;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+    using RTCV.Common;
+    using RTCV.UI.Modular;
+
     public class UIConnector : IRoutable
     {
         private NetCoreReceiver receiver;

--- a/Source/Frontend/UI/UICore.cs
+++ b/Source/Frontend/UI/UICore.cs
@@ -1,22 +1,22 @@
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Threading;
-using System.Timers;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using RTCV.Common;
-using RTCV.UI.Input;
-using RTCV.UI.Modular;
-using static RTCV.NetCore.NetcoreCommands;
-using static RTCV.UI.UI_Extensions;
-
 namespace RTCV.UI
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Drawing;
+    using System.IO;
+    using System.Linq;
+    using System.Reflection;
+    using System.Threading;
+    using System.Timers;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+    using RTCV.Common;
+    using RTCV.UI.Input;
+    using RTCV.UI.Modular;
+    using static RTCV.NetCore.NetcoreCommands;
+    using static RTCV.UI.UI_Extensions;
+
     public static class UICore
     {
         //Note Box Settings
@@ -394,7 +394,7 @@ namespace RTCV.UI
                 {
                     if (targetForm != null)
                     {
-                        foreach(var c in targetForm.Controls.getControlsWithTag())
+                        foreach (var c in targetForm.Controls.getControlsWithTag())
                             allControls.Add(c);
                         allControls.Add(targetForm);
                     }
@@ -900,7 +900,7 @@ namespace RTCV.UI
                 return;
             }
 
-            
+
             //x.Substring(x.LastIndexOf('\\')+1)[0] != '$'
             //checks if first char is $
 

--- a/Source/Frontend/UI/UI_Extensions.cs
+++ b/Source/Frontend/UI/UI_Extensions.cs
@@ -113,7 +113,7 @@ namespace RTCV.UI
             {
                 logger.Error(ex, $"Failed to get form screenshot.");
                 return new Bitmap(1, 1);
-            };
+            }
         }
 
         #region CONTROL EXTENSIONS
@@ -267,21 +267,21 @@ namespace RTCV.UI
                 {
                     this.Hide();                //If the target panel hosts another ComponentForm, we won't override it
                 }
-                else                            //This is most likely going to happen if a VMD ComponentForm was changed to a window, 
+                else                            //This is most likely going to happen if a VMD ComponentForm was changed to a window,
                 {
                     AnchorToPanel(targetPanel); //then another VMD tool was selected and that window was closed
                 }
             }
 
             /* Note: Visual studio is so dumb, the designer won't allow to bind an event to a method in the base class
-			   Just paste the following code at the beginning of the ComponentForm class to fix this stupid shit
+               Just paste the following code at the beginning of the ComponentForm class to fix this stupid shit
 
-			public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);
-			public new void HandleFormClosing(object s, FormClosingEventArgs e) => base.HandleFormClosing(s, e);
+            public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);
+            public new void HandleFormClosing(object s, FormClosingEventArgs e) => base.HandleFormClosing(s, e);
 
-			ALSO, GroupBox does have an event handler for MouseDown but michaelsoft are too high on crack to let
-			us bind something to it in the properties panel. Gotta add it manually in the designer.cs ffs.
-			*/
+            ALSO, GroupBox does have an event handler for MouseDown but michaelsoft are too high on crack to let
+            us bind something to it in the properties panel. Gotta add it manually in the designer.cs ffs.
+            */
 
             public void HandleMouseDown(object sender, MouseEventArgs e)
             {
@@ -386,7 +386,6 @@ namespace RTCV.UI
 
             public bool AllowNegative { get; set; }
         }
-
     }
 
     //From Bizhawk
@@ -1468,12 +1467,12 @@ namespace RTCV.UI
                     bool cellSelected = (cellState & DataGridViewElementStates.Selected) != 0;
 
                     /*if (renderingBitmap.Width < valBounds.Width ||
-						renderingBitmap.Height < valBounds.Height)
-					{
-						// The static bitmap is too small, a bigger one needs to be allocated.
-						renderingBitmap.Dispose();
-						renderingBitmap = new Bitmap(valBounds.Width, valBounds.Height);
-					}*/
+                        renderingBitmap.Height < valBounds.Height)
+                    {
+                        // The static bitmap is too small, a bigger one needs to be allocated.
+                        renderingBitmap.Dispose();
+                        renderingBitmap = new Bitmap(valBounds.Width, valBounds.Height);
+                    }*/
 
                     //7/1/2018
                     //OPTIMIZE PAINTING BY REMOVING UNUSED FUNCTIONALITY
@@ -1481,14 +1480,14 @@ namespace RTCV.UI
 
                     // Make sure the NumericUpDown control is parented to a visible control
                     /*
-					if (paintingNumericUpDown.Parent == null || !paintingNumericUpDown.Parent.Visible)
-					{
-						paintingNumericUpDown.Parent = this.DataGridView;
-					}
-					paintingNumericUpDown.RightToLeft = this.DataGridView.RightToLeft;
-					paintingNumericUpDown.ThousandsSeparator = this.ThousandsSeparator;
-					paintingNumericUpDown.TextAlign = DataGridViewNumericUpDownCell.TranslateAlignment(cellStyle.Alignment);
-					paintingNumericUpDown.DecimalPlaces = this.DecimalPlaces;*/
+                    if (paintingNumericUpDown.Parent == null || !paintingNumericUpDown.Parent.Visible)
+                    {
+                        paintingNumericUpDown.Parent = this.DataGridView;
+                    }
+                    paintingNumericUpDown.RightToLeft = this.DataGridView.RightToLeft;
+                    paintingNumericUpDown.ThousandsSeparator = this.ThousandsSeparator;
+                    paintingNumericUpDown.TextAlign = DataGridViewNumericUpDownCell.TranslateAlignment(cellStyle.Alignment);
+                    paintingNumericUpDown.DecimalPlaces = this.DecimalPlaces;*/
 
                     // Set all the relevant properties
                     paintingNumericUpDown.Value = Convert.ToDecimal(value);
@@ -1540,14 +1539,14 @@ namespace RTCV.UI
                     }
                     // Finally paint the NumericUpDown control
                     /*
-					Rectangle srcRect = new Rectangle(0, 0, valBounds.Width, valBounds.Height);
-					if (srcRect.Width > 0 && srcRect.Height > 0)
-					{
-						
-						paintingNumericUpDown.DrawToBitmap(renderingBitmap, srcRect);
-						graphics.DrawImage(renderingBitmap, new Rectangle(valBounds.Location, valBounds.Size),
-										   srcRect, GraphicsUnit.Pixel);
-					}*/
+                    Rectangle srcRect = new Rectangle(0, 0, valBounds.Width, valBounds.Height);
+                    if (srcRect.Width > 0 && srcRect.Height > 0)
+                    {
+
+                        paintingNumericUpDown.DrawToBitmap(renderingBitmap, srcRect);
+                        graphics.DrawImage(renderingBitmap, new Rectangle(valBounds.Location, valBounds.Size),
+                                           srcRect, GraphicsUnit.Pixel);
+                    }*/
                 }
                 if (PartPainted(paintParts, DataGridViewPaintParts.ErrorIcon))
                 {
@@ -1993,7 +1992,7 @@ namespace RTCV.UI
             NotifyDataGridViewOfValueChange();
         }
 
-        //Handle OnLostFocus to update if you paste. 
+        //Handle OnLostFocus to update if you paste.
         //Intercepting paste doesn't work and OnValueChanged also doesn't
         protected override void OnLostFocus(EventArgs e)
         {
@@ -2002,48 +2001,48 @@ namespace RTCV.UI
         }
 
         /*
-		/// <summary>
-		/// Listen to the KeyPress notification to know when the value changed, and
-		/// notify the grid of the change.
-		/// </summary>
-		protected override void OnKeyPress(KeyPressEventArgs e)
-		{
-			base.OnKeyPress(e);
+        /// <summary>
+        /// Listen to the KeyPress notification to know when the value changed, and
+        /// notify the grid of the change.
+        /// </summary>
+        protected override void OnKeyPress(KeyPressEventArgs e)
+        {
+            base.OnKeyPress(e);
 
-			// The value changes when a digit, the decimal separator, the group separator or
-			// the negative sign is pressed.
-			bool notifyValueChange = false;
-			if (char.IsDigit(e.KeyChar) || (e.KeyChar >= 'a' && e.KeyChar <= 'f') || (e.KeyChar >= 'A' && e.KeyChar <= 'F') || (e.KeyChar == '\b' || (e.KeyChar == (char)Keys.ControlKey && e.KeyChar == (char)Keys.V)))
-			{
-				notifyValueChange = true;
-			}
-			else
-			{
-				System.Globalization.NumberFormatInfo numberFormatInfo = System.Globalization.CultureInfo.CurrentCulture.NumberFormat;
-				string decimalSeparatorStr = numberFormatInfo.NumberDecimalSeparator;
-				string groupSeparatorStr = numberFormatInfo.NumberGroupSeparator;
-				string negativeSignStr = numberFormatInfo.NegativeSign;
-				if (!string.IsNullOrEmpty(decimalSeparatorStr) && decimalSeparatorStr.Length == 1)
-				{
-					notifyValueChange = decimalSeparatorStr[0] == e.KeyChar;
-				}
-				if (!notifyValueChange && !string.IsNullOrEmpty(groupSeparatorStr) && groupSeparatorStr.Length == 1)
-				{
-					notifyValueChange = groupSeparatorStr[0] == e.KeyChar;
-				}
-				if (!notifyValueChange && !string.IsNullOrEmpty(negativeSignStr) && negativeSignStr.Length == 1)
-				{
-					notifyValueChange = negativeSignStr[0] == e.KeyChar;
-				}
-			}
+            // The value changes when a digit, the decimal separator, the group separator or
+            // the negative sign is pressed.
+            bool notifyValueChange = false;
+            if (char.IsDigit(e.KeyChar) || (e.KeyChar >= 'a' && e.KeyChar <= 'f') || (e.KeyChar >= 'A' && e.KeyChar <= 'F') || (e.KeyChar == '\b' || (e.KeyChar == (char)Keys.ControlKey && e.KeyChar == (char)Keys.V)))
+            {
+                notifyValueChange = true;
+            }
+            else
+            {
+                System.Globalization.NumberFormatInfo numberFormatInfo = System.Globalization.CultureInfo.CurrentCulture.NumberFormat;
+                string decimalSeparatorStr = numberFormatInfo.NumberDecimalSeparator;
+                string groupSeparatorStr = numberFormatInfo.NumberGroupSeparator;
+                string negativeSignStr = numberFormatInfo.NegativeSign;
+                if (!string.IsNullOrEmpty(decimalSeparatorStr) && decimalSeparatorStr.Length == 1)
+                {
+                    notifyValueChange = decimalSeparatorStr[0] == e.KeyChar;
+                }
+                if (!notifyValueChange && !string.IsNullOrEmpty(groupSeparatorStr) && groupSeparatorStr.Length == 1)
+                {
+                    notifyValueChange = groupSeparatorStr[0] == e.KeyChar;
+                }
+                if (!notifyValueChange && !string.IsNullOrEmpty(negativeSignStr) && negativeSignStr.Length == 1)
+                {
+                    notifyValueChange = negativeSignStr[0] == e.KeyChar;
+                }
+            }
 
-			if (notifyValueChange)
-			{
-				// Let the DataGridView know about the value change
-				NotifyDataGridViewOfValueChange();
-			}
-		}
-		*/
+            if (notifyValueChange)
+            {
+                // Let the DataGridView know about the value change
+                NotifyDataGridViewOfValueChange();
+            }
+        }
+        */
 
         /// <summary>
         /// Listen to the ValueChanged notification to forward the change to the grid.
@@ -2140,9 +2139,8 @@ namespace RTCV.UI
                 ChangingText = false;
             }
 
-            //	if(base.Hexadecimal)
-            //	base.Text = GetNumberText(base.Value);
-
+            //    if(base.Hexadecimal)
+            //    base.Text = GetNumberText(base.Value);
         }
 
         protected override void ValidateEditText()
@@ -2186,7 +2184,7 @@ namespace RTCV.UI
                     if (val > Maximum)
                     {
                         base.Text = string.Format("{0:X}", (uint)Maximum);
-                        //	val = (uint)Maximum;
+                        //    val = (uint)Maximum;
                     }
 
                     if (!string.IsNullOrEmpty(base.Text))
@@ -2259,9 +2257,9 @@ namespace RTCV.UI
 
                 if (rowIndex >= 0)
                 {
-                    // Remember the point where the mouse down occurred. 
-                    // The DragSize indicates the size that the mouse can move 
-                    // before a drag event should be started.                
+                    // Remember the point where the mouse down occurred.
+                    // The DragSize indicates the size that the mouse can move
+                    // before a drag event should be started.
                     Size dragSize = SystemInformation.DragSize;
 
                     // Create a rectangle using the DragSize, with the mouse position being
@@ -2316,7 +2314,7 @@ namespace RTCV.UI
 
         private new void DragDrop(object sender, DragEventArgs e)
         {
-            // The mouse locations are relative to the screen, so they must be 
+            // The mouse locations are relative to the screen, so they must be
             // converted to client coordinates.
             Point clientPoint = this.PointToClient(new Point(e.X, e.Y));
 
@@ -2337,7 +2335,7 @@ namespace RTCV.UI
                         this.Rows.Remove(row);
                     }
 
-                    // Get the row index of the item the mouse is below. 
+                    // Get the row index of the item the mouse is below.
                     var hitTest = this.HitTest(clientPoint.X, clientPoint.Y);
                     rowIndexOfItemUnderMouseToDrop = hitTest.RowIndex;
                     if (rowIndexOfItemUnderMouseToDrop == -1)
@@ -2631,7 +2629,7 @@ public class SortableBindingList<T> : BindingList<T> where T : class
 
 //From bizhawk
 /// <summary>
-/// A dictionary that creates new values on the fly as necessary so that any key you need will be defined. 
+/// A dictionary that creates new values on the fly as necessary so that any key you need will be defined.
 /// </summary>
 /// <typeparam name="K">dictionary keys</typeparam>
 /// <typeparam name="V">dictionary values</typeparam>

--- a/Source/Frontend/UI/UI_VanguardImplementation.cs
+++ b/Source/Frontend/UI/UI_VanguardImplementation.cs
@@ -1,16 +1,16 @@
-using System;
-using System.Drawing;
-using System.IO;
-using System.Linq;
-using System.Windows.Forms;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using RTCV.Common;
-using RTCV.UI.Modular;
-using static RTCV.NetCore.NetcoreCommands;
-
 namespace RTCV.UI
 {
+    using System;
+    using System.Drawing;
+    using System.IO;
+    using System.Linq;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+    using RTCV.Common;
+    using RTCV.UI.Modular;
+    using static RTCV.NetCore.NetcoreCommands;
+
     public static class UI_VanguardImplementation
     {
         public static UIConnector connector = null;
@@ -68,7 +68,7 @@ namespace RTCV.UI
                         }
                         break;
 
-                    case REMOTE_ALLSPECSSENT: 
+                    case REMOTE_ALLSPECSSENT:
                         if (UICore.FirstConnect)
                         {
                             UICore.Initialized.WaitOne(10000);
@@ -76,8 +76,6 @@ namespace RTCV.UI
 
                         SyncObjectSingleton.FormExecute(() =>
                         {
-
-                            
                             if (UICore.FirstConnect)
                             {
                                 lastVanguardClient = (string)RTCV.NetCore.AllSpec.VanguardSpec?[VSPEC.NAME] ?? "VANGUARD";
@@ -122,7 +120,6 @@ namespace RTCV.UI
                                 UI_DefaultGrids.engineConfig.LoadToMain();
 
                                 UI_DefaultGrids.glitchHarvester.LoadToNewWindow("Glitch Harvester", true);
-
                             }
                             else
                             {
@@ -158,7 +155,7 @@ namespace RTCV.UI
                                 S.GET<UI_CoreForm>().previousGrid.LoadToMain();
                             }
 
-                            S.GET<UI_CoreForm>().pbAutoKillSwitchTimeout.Value = 0;//remove this once core form is dead
+                            S.GET<UI_CoreForm>().pbAutoKillSwitchTimeout.Value = 0; //remove this once core form is dead
 
                             if (!CorruptCore.RtcCore.Attached)
                             {
@@ -260,11 +257,10 @@ namespace RTCV.UI
 
                             if (RTCV.UI.UI_Extensions.GetInputBox("VMD Generation", "Enter the new VMD name:", ref value) == DialogResult.OK)
                             {
-                                if(!string.IsNullOrWhiteSpace(value))
+                                if (!string.IsNullOrWhiteSpace(value))
                                     vmdgenerator.tbVmdName.Text = value.Trim();
                                 vmdgenerator.btnGenerateVMD_Click(null, null);
                             }
-
                         });
                         e.setReturnValue(true);
                         break;

--- a/Source/Libraries/Common/Common.csproj
+++ b/Source/Libraries/Common/Common.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <CodeAnalysisRuleSet>..\..\..\StyleCop.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Source/Libraries/Common/Controls/LogConsole.cs
+++ b/Source/Libraries/Common/Controls/LogConsole.cs
@@ -1,15 +1,13 @@
-using System;
-using System.Drawing;
-using System.Windows.Forms;
-using NLog;
-using NLog.Layouts;
-using NLog.Windows.Forms;
-
 namespace RTCV.Common.Forms
 {
+    using System.Drawing;
+    using System.Windows.Forms;
+    using NLog;
+    using NLog.Layouts;
+    using NLog.Windows.Forms;
+
     public partial class LogConsole : UserControl
     {
-
         public override Color ForeColor
         {
             get => base.ForeColor;
@@ -90,7 +88,7 @@ namespace RTCV.Common.Forms
         }
         public void InitializeCustomLogger(int maxLines, Layout layout, string fileName = null)
         {
-            if(layout == null)
+            if (layout == null)
                 layout = "${level} ${logger} ${message} ${onexception:|${newline}EXCEPTION OCCURRED\\:${exception:format=type,message,method:maxInnerExceptionLevel=5:innerFormat=shortType,message,method}${newline}";
 
             var config = new NLog.Config.LoggingConfiguration();
@@ -100,7 +98,7 @@ namespace RTCV.Common.Forms
                 var logfile = new NLog.Targets.FileTarget("logfile") { FileName = fileName, Layout = layout };
                 config.AddRule(LogLevel.Trace, LogLevel.Fatal, logfile);
             }
-            
+
             var t = GetRichTextBoxTarget(1000, layout);
             config.AddRule(LogLevel.Trace, LogLevel.Fatal, t);
 
@@ -117,6 +115,5 @@ namespace RTCV.Common.Forms
             InitializeComponent();
             InitializeCustomLogger(maxLines, customLayout, fileName);
         }
-
     }
 }

--- a/Source/Libraries/Common/Controls/ToolStripEx.cs
+++ b/Source/Libraries/Common/Controls/ToolStripEx.cs
@@ -1,15 +1,12 @@
 //credit: http://blogs.msdn.com/b/rickbrew/archive/2006/01/09/511003.aspx
-
-using System;
-using System.Windows.Forms;
-
 /// <summary>
 /// This class adds on to the functionality provided in System.Windows.Forms.ToolStrip.
 /// </summary>
-
-
 namespace RTCV.Common.Controls
 {
+    using System;
+    using System.Windows.Forms;
+
     public class ToolStripEx : ToolStrip
     {
         private bool clickThrough = true;

--- a/Source/Libraries/Common/Forms/LogConsoleForm.cs
+++ b/Source/Libraries/Common/Forms/LogConsoleForm.cs
@@ -1,17 +1,10 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-using NLog;
-using NLog.Layouts;
-
 namespace RTCV.Common.Forms
 {
+    using System.Drawing;
+    using System.Windows.Forms;
+    using NLog;
+    using NLog.Layouts;
+
     public partial class LogConsoleForm : Form
     {
         public bool HideOnClose = false;

--- a/Source/Libraries/Common/Logging.cs
+++ b/Source/Libraries/Common/Logging.cs
@@ -1,14 +1,14 @@
-using System;
-using System.Diagnostics;
-using System.IO;
-using System.Text;
-using System.Linq;
-using NLog;
-using NLog.LayoutRenderers;
-using NLog.Layouts;
-
 namespace RTCV.Common
 {
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Text;
+    using System.Linq;
+    using NLog;
+    using NLog.LayoutRenderers;
+    using NLog.Layouts;
+
     public static class Logging
     {
         public static Logger GlobalLogger = LogManager.GetLogger("Global");
@@ -71,10 +71,10 @@ namespace RTCV.Common
                 config.AddRule(LogLevel.Trace, LogLevel.Fatal, logconsole);
             else
                 config.AddRule(LogLevel.Debug, LogLevel.Fatal, logconsole);
-            // Rules for mapping loggers to targets            
+            // Rules for mapping loggers to targets
             //config.AddRule(LogLevel.Trace, LogLevel.Fatal, logfile);
 
-            // Apply config           
+            // Apply config
             NLog.LogManager.Configuration = config;
             Common.ConsoleHelper.CreateConsole(filename);
             if (!Environment.GetCommandLineArgs().Any(x => string.Equals(x, "-CONSOLE", StringComparison.OrdinalIgnoreCase)))

--- a/Source/Libraries/Common/Objects/OperationResults.cs
+++ b/Source/Libraries/Common/Objects/OperationResults.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
-using System.Text;
-
-namespace RTCV.Common.Objects
+﻿namespace RTCV.Common.Objects
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Linq;
+    using System.Text;
+
     public class OperationResult
     {
         public readonly string Message;

--- a/Source/Libraries/Common/StaticTools.cs
+++ b/Source/Libraries/Common/StaticTools.cs
@@ -1,21 +1,18 @@
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-using System.Reflection;
-using NLog;
-
 namespace RTCV.Common
 {
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Linq;
+    using System.Runtime.InteropServices;
+    using System.Text;
+    using System.Threading;
+    using System.Windows.Forms;
+    using NLog;
+
     // Implementing this interface causes auto-coloration.
     public interface IAutoColorize { }
 
@@ -89,7 +86,7 @@ namespace RTCV.Common
         }
 
         private static Type FINDTYPE(string name, bool any = false)
-        { 
+        {
             //thx https://stackoverflow.com/questions/4692340/find-types-in-all-assemblies
 
             return
@@ -204,7 +201,6 @@ namespace RTCV.Common
 
         public static void CreateConsole(string path = null)
         {
-
             if (!Debugger.IsAttached) //Don't override debugger's console
             {
                 ReleaseConsole();

--- a/Source/Libraries/CorruptCore/BitlogicListFilter.cs
+++ b/Source/Libraries/CorruptCore/BitlogicListFilter.cs
@@ -1,13 +1,13 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Security.Cryptography;
-using System.Windows.Forms;
-using Ceras;
-
 namespace RTCV.CorruptCore
 {
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Security.Cryptography;
+    using System.Windows.Forms;
+    using Ceras;
+
     [Serializable]
     [Ceras.MemberConfig(TargetMember.All)]
     public class BitlogicListFilter : IListFilter
@@ -41,12 +41,11 @@ namespace RTCV.CorruptCore
                             doFlipBytes = true;
                         }
                         options.Add(flag); //add as flag to hashset
-
                     }
                     else
                     {
                         if (inHeader) { inHeader = false; }
-                        var e = ParseLine(j + 2, filePath, dataLines[j], doFlipBytes);//Parse lines individually
+                        var e = ParseLine(j + 2, filePath, dataLines[j], doFlipBytes); //Parse lines individually
                         if (e != null)
                         {
                             entries.Add(e);
@@ -56,9 +55,8 @@ namespace RTCV.CorruptCore
 
                 if (entries.Count == 0)
                 {
-                    throw new Exception($"Error reading list {Path.GetFileName(filePath)}, list was empty or contained no valid lines");//show message to user
+                    throw new Exception($"Error reading list {Path.GetFileName(filePath)}, list was empty or contained no valid lines"); //show message to user
                 }
-
             }
             catch (Exception e)
             {
@@ -93,7 +91,7 @@ namespace RTCV.CorruptCore
         {
             try
             {
-                ulong data = BytesToUlong(bytes);//Convert bytes to ulong 
+                ulong data = BytesToUlong(bytes); //Convert bytes to ulong
                 foreach (var e in entries)
                 {
                     if (e.Matches(data))
@@ -119,7 +117,7 @@ namespace RTCV.CorruptCore
             //When passthrough is implemented, work here
             var rval = entries[RtcCore.RND.Next(entries.Count)];
             var outValue = BitConverter.GetBytes(rval.GetRandom(/*BytesToUlong(bytes)*/)); //Bitconverter as little endian
-            Array.Resize(ref outValue, rval.Precision);//discard the last bytes
+            Array.Resize(ref outValue, rval.Precision); //discard the last bytes
 
             //Copied and pasted from other list implementations
             if (outValue.Length < precision)
@@ -188,7 +186,7 @@ namespace RTCV.CorruptCore
         {
             bool flipBytes = !doFlipBytes; //to maintain sanity
 
-            line = line.Trim();//remove whitespace on both sides
+            line = line.Trim(); //remove whitespace on both sides
             string originalLine = line;
 
             //Ignore empty lines and comments
@@ -319,7 +317,7 @@ namespace RTCV.CorruptCore
         {
             //Could be refactored and merged with ParseBin probably
 
-            const ulong digitMask = 0b1111;//ulong mask for one hex digit
+            const ulong digitMask = 0b1111; //ulong mask for one hex digit
 
             ulong template = 0UL;
             ulong wildcard = 0UL;
@@ -374,7 +372,6 @@ namespace RTCV.CorruptCore
 
             return new BitlogicFilterEntry(template, wildcard, passthrough, reserved, GetPrecision(line, 1));
         }
-
     }
 
     /// <summary>
@@ -400,7 +397,6 @@ namespace RTCV.CorruptCore
         static byte[] byteBuffer = new byte[sizeof(ulong)];
         static ulong NextULong()
         {
-
             RtcCore.RND.NextBytes(byteBuffer);
             return BitConverter.ToUInt64(byteBuffer, 0);
         }

--- a/Source/Libraries/CorruptCore/Blast Generator Engines/RTC_StoreGenerator.cs
+++ b/Source/Libraries/CorruptCore/Blast Generator Engines/RTC_StoreGenerator.cs
@@ -1,7 +1,7 @@
-using System;
-
 namespace RTCV.CorruptCore
 {
+    using System;
+
     public class RTC_StoreGenerator
     {
         public static BlastLayer GenerateLayer(string note, string domain, long stepSize, long startAddress, long endAddress,

--- a/Source/Libraries/CorruptCore/Blast Generator Engines/RTC_ValueGenerator.cs
+++ b/Source/Libraries/CorruptCore/Blast Generator Engines/RTC_ValueGenerator.cs
@@ -1,9 +1,9 @@
-using System;
-using System.Linq;
-using System.Numerics;
-
 namespace RTCV.CorruptCore
 {
+    using System;
+    using System.Linq;
+    using System.Numerics;
+
     public static class RTC_ValueGenerator
     {
         private static byte[] param1Bytes;

--- a/Source/Libraries/CorruptCore/BlastDiff.cs
+++ b/Source/Libraries/CorruptCore/BlastDiff.cs
@@ -1,10 +1,10 @@
-using System.Collections.Generic;
-using System.Linq;
-using System.Windows.Forms;
-using RTCV.NetCore;
-
 namespace RTCV.CorruptCore
 {
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Windows.Forms;
+    using RTCV.NetCore;
+
     public static class BlastDiff
     {
         public static BlastLayer GetBlastLayer(string filename)
@@ -147,7 +147,6 @@ namespace RTCV.CorruptCore
 
                     bu.BigEndian = Original[0].BigEndian;
                     bl.Layer.Add(bu);
-
                 }
             }
 

--- a/Source/Libraries/CorruptCore/BlastTools.cs
+++ b/Source/Libraries/CorruptCore/BlastTools.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Windows.Forms;
-using Newtonsoft.Json;
-
-namespace RTCV.CorruptCore
+﻿namespace RTCV.CorruptCore
 {
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Windows.Forms;
+    using Newtonsoft.Json;
+
     public static class BlastTools
     {
         public static string LastBlastLayerSavePath { get; set; }
@@ -202,7 +202,7 @@ namespace RTCV.CorruptCore
         /// <param name="sk"></param>
         /// <param name="loadBeforeCorrupt"></param>
         /// <returns></returns>
-		public static List<BlastGeneratorProto> GenerateBlastLayersFromBlastGeneratorProtos(List<BlastGeneratorProto> blastLayers, StashKey sk)
+        public static List<BlastGeneratorProto> GenerateBlastLayersFromBlastGeneratorProtos(List<BlastGeneratorProto> blastLayers, StashKey sk)
         {
             foreach (BlastGeneratorProto bgp in blastLayers)
             {

--- a/Source/Libraries/CorruptCore/Coroutines/Conditionals/WaitFrames.cs
+++ b/Source/Libraries/CorruptCore/Coroutines/Conditionals/WaitFrames.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace RTCV.CorruptCore.Coroutines
 {
     /// <summary>

--- a/Source/Libraries/CorruptCore/Coroutines/Conditionals/WaitUntil.cs
+++ b/Source/Libraries/CorruptCore/Coroutines/Conditionals/WaitUntil.cs
@@ -1,11 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace RTCV.CorruptCore.Coroutines
 {
+    using System;
+
     public class WaitUntil : Yielder
     {
         Func<bool> pred;

--- a/Source/Libraries/CorruptCore/Coroutines/Coroutine.cs
+++ b/Source/Libraries/CorruptCore/Coroutines/Coroutine.cs
@@ -1,11 +1,8 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace RTCV.CorruptCore.Coroutines
 {
+    using System;
+    using System.Collections.Generic;
+
     //Can probably simplify logic or refactor
 
     /// <summary>
@@ -37,7 +34,7 @@ namespace RTCV.CorruptCore.Coroutines
 
         public void Dispose()
         {
-            if(coroutine != null)
+            if (coroutine != null)
             {
                 coroutine.Dispose();
             }
@@ -45,7 +42,7 @@ namespace RTCV.CorruptCore.Coroutines
 
         public void DoCycle()
         {
-            if(IsComplete)
+            if (IsComplete)
             {
                 //Do nothing
             }

--- a/Source/Libraries/CorruptCore/Coroutines/CoroutineEngine.cs
+++ b/Source/Libraries/CorruptCore/Coroutines/CoroutineEngine.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace RTCV.CorruptCore.Coroutines
 {
     /// <summary>

--- a/Source/Libraries/CorruptCore/Coroutines/CoroutineRunner.cs
+++ b/Source/Libraries/CorruptCore/Coroutines/CoroutineRunner.cs
@@ -1,11 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace RTCV.CorruptCore.Coroutines
 {
+    using System.Collections.Generic;
+
     /// <summary>
     /// Used to manage and run coroutines
     /// </summary>
@@ -59,6 +55,5 @@ namespace RTCV.CorruptCore.Coroutines
                 curCoroutineNode = nextNode;
             }
         }
-
     }
 }

--- a/Source/Libraries/CorruptCore/Coroutines/Yielder.cs
+++ b/Source/Libraries/CorruptCore/Coroutines/Yielder.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace RTCV.CorruptCore.Coroutines
 {
     public abstract class Yielder

--- a/Source/Libraries/CorruptCore/CorruptCore.cs
+++ b/Source/Libraries/CorruptCore/CorruptCore.cs
@@ -1,23 +1,22 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-using Newtonsoft.Json;
-using RTCV.NetCore;
-using RTCV.PluginHost;
-using RTCV.Common;
-using Timer = System.Windows.Forms.Timer;
-
 namespace RTCV.CorruptCore
 {
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Reflection;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Windows.Forms;
+    using Newtonsoft.Json;
+    using RTCV.NetCore;
+    using RTCV.PluginHost;
+    using Timer = System.Windows.Forms.Timer;
+
     public static class RtcCore
     {
         //General RTC Values
@@ -324,8 +323,8 @@ namespace RTCV.CorruptCore
         }
 
         /**
-		* Register the spec on the rtc side
-		*/
+        * Register the spec on the rtc side
+        */
         public static void RegisterCorruptcoreSpec()
         {
             try
@@ -367,11 +366,11 @@ namespace RTCV.CorruptCore
                 };
 
                 /*
-				if (RTC_StockpileManager.BackupedState != null)
-					RTC_StockpileManager.BackupedState.Run();
-				else
-					CorruptCoreSpec.Update(RTCSPEC.CORE_AUTOCORRUPT.ToString(), false);
-					*/
+                if (RTC_StockpileManager.BackupedState != null)
+                    RTC_StockpileManager.BackupedState.Run();
+                else
+                    CorruptCoreSpec.Update(RTCSPEC.CORE_AUTOCORRUPT.ToString(), false);
+                    */
             }
             catch (Exception ex)
             {
@@ -1025,11 +1024,11 @@ namespace RTCV.CorruptCore
         }
 
         /*
-		public static void ApplyBlastLayer(BlastLayer bl)
-		{
-			if(bl.Layer != null)
-				bl.Apply();
-		}*/
+        public static void ApplyBlastLayer(BlastLayer bl)
+        {
+            if(bl.Layer != null)
+                bl.Apply();
+        }*/
 
         public static void OnProgressBarUpdate(object sender, ProgressBarEventArgs e)
         {

--- a/Source/Libraries/CorruptCore/CorruptCore.cs
+++ b/Source/Libraries/CorruptCore/CorruptCore.cs
@@ -1075,7 +1075,6 @@ namespace RTCV.CorruptCore
                     if (bl != null)
                         bl.Apply(false, false);
                 }
-
             }
         }
 

--- a/Source/Libraries/CorruptCore/CorruptCore.csproj
+++ b/Source/Libraries/CorruptCore/CorruptCore.csproj
@@ -44,7 +44,6 @@
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>latest</LangVersion>
     <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>..\..\..\Build\</OutputPath>
@@ -55,7 +54,6 @@
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>latest</LangVersion>
     <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
+++ b/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
@@ -1,14 +1,14 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-using RTCV.NetCore;
-using static RTCV.NetCore.NetcoreCommands;
-
 namespace RTCV.CorruptCore
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Windows.Forms;
+    using RTCV.NetCore;
+    using static RTCV.NetCore.NetcoreCommands;
+
     public class CorruptCoreConnector : IRoutable
     {
         private static volatile object _loadLock = new object();
@@ -149,7 +149,6 @@ namespace RTCV.CorruptCore
                             }
                             else
                             {
-
                                 //Route it to the plugin if loaded
                                 if (RtcCore.PluginHost.LoadedPlugins.Any(x => x.Name == "Hex Editor"))
                                     LocalNetCoreRouter.Route("HEXEDITOR", NetcoreCommands.REMOTE_OPENHEXEDITOR, true);
@@ -626,7 +625,7 @@ namespace RTCV.CorruptCore
 
                     case REMOTE_LOADPLUGINS:
                         SyncObjectSingleton.FormExecute(() =>
-                        { 
+                        {
                             string emuPluginDir = "";
                             try
                             {
@@ -636,7 +635,7 @@ namespace RTCV.CorruptCore
                             {
                                 RTCV.Common.Logging.GlobalLogger.Error(e, "Unable to find plugin dir in {dir}", RtcCore.EmuDir + "\\RTC" + "\\PLUGINS");
                             }
-                            RtcCore.LoadPlugins(new[] { RtcCore.pluginDir,  emuPluginDir});
+                            RtcCore.LoadPlugins(new[] { RtcCore.pluginDir,  emuPluginDir });
                         });
 
                         break;

--- a/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
+++ b/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
@@ -303,10 +303,10 @@ namespace RTCV.CorruptCore
 
                             if (temp.Length > 2)
                                  merge = (bool)temp[2];
-                            
+
 
                             void a()
-                            { 
+                            {
                                 bl.Apply(storeUncorruptBackup, true, merge);
                             }
 

--- a/Source/Libraries/CorruptCore/CorruptCore_Extensions.cs
+++ b/Source/Libraries/CorruptCore/CorruptCore_Extensions.cs
@@ -703,7 +703,7 @@
 
             var newArray = new byte[bytes.Length];
 
-            for(int i=0;i<bytes.Length;i++)
+            for (int i=0; i<bytes.Length; i++)
             {
                 if (bytes[i] == null)
                     newArray[i] = 69;
@@ -1005,7 +1005,6 @@
 
                 for (int i = 0; i < a.Length; i++)
                 {
-
                     if (a[i] != b[i])
                     {
                         return false;

--- a/Source/Libraries/CorruptCore/CorruptCore_Extensions.cs
+++ b/Source/Libraries/CorruptCore/CorruptCore_Extensions.cs
@@ -1,24 +1,24 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Drawing;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Numerics;
-using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Runtime.Serialization.Formatters.Binary;
-using System.Text;
-using System.Windows.Forms;
-using Ceras;
-using Newtonsoft.Json;
-using RTCV.NetCore;
-
-namespace RTCV.CorruptCore
+﻿namespace RTCV.CorruptCore
 {
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Diagnostics;
+    using System.Drawing;
+    using System.Globalization;
+    using System.IO;
+    using System.Linq;
+    using System.Numerics;
+    using System.Reflection;
+    using System.Runtime.InteropServices;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using System.Text;
+    using System.Windows.Forms;
+    using Ceras;
+    using Newtonsoft.Json;
+    using RTCV.NetCore;
+
     public static class CorruptCore_Extensions
     {
         public static void DirectoryRequired(string path)
@@ -512,7 +512,7 @@ namespace RTCV.CorruptCore
                             bigIntValue -= bigintAddValueAbs;
                         }
 
-                        //Calculate the max value you can store in this many bits 
+                        //Calculate the max value you can store in this many bits
                         BigInteger maxValue = BigInteger.Pow(2, value.Length * 8) - 1;
 
                         if (bigIntValue > maxValue)
@@ -1338,8 +1338,8 @@ namespace RTCV.CorruptCore
                 if (Win32.AllocConsole())
                 {
                     //set icons for the console so we can tell them apart from the main window
-                    //		Win32.SendMessage(Win32.GetConsoleWindow(), 0x0080/*WM_SETICON*/, (IntPtr)0/*ICON_SMALL*/, Properties.Resources.console16x16.GetHicon());
-                    //		Win32.SendMessage(Win32.GetConsoleWindow(), 0x0080/*WM_SETICON*/, (IntPtr)1/*ICON_LARGE*/, Properties.Resources.console32x32.GetHicon());
+                    //    Win32.SendMessage(Win32.GetConsoleWindow(), 0x0080/*WM_SETICON*/, (IntPtr)0/*ICON_SMALL*/, Properties.Resources.console16x16.GetHicon());
+                    //    Win32.SendMessage(Win32.GetConsoleWindow(), 0x0080/*WM_SETICON*/, (IntPtr)1/*ICON_LARGE*/, Properties.Resources.console32x32.GetHicon());
                     hasConsole = true;
                 }
                 else

--- a/Source/Libraries/CorruptCore/Corruption Engines/RTC_BlastGeneratorEngine.cs
+++ b/Source/Libraries/CorruptCore/Corruption Engines/RTC_BlastGeneratorEngine.cs
@@ -1,5 +1,4 @@
-﻿
-namespace RTCV.CorruptCore
+﻿namespace RTCV.CorruptCore
 {
     public static class RTC_BlastGeneratorEngine
     {

--- a/Source/Libraries/CorruptCore/Corruption Engines/RTC_CustomEngine.cs
+++ b/Source/Libraries/CorruptCore/Corruption Engines/RTC_CustomEngine.cs
@@ -1,14 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.IO;
-using System.Linq;
-using System.Numerics;
-using System.Windows.Forms;
-using RTCV.NetCore;
-
-namespace RTCV.CorruptCore
+﻿namespace RTCV.CorruptCore
 {
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.IO;
+    using System.Linq;
+    using System.Numerics;
+    using System.Windows.Forms;
+    using RTCV.NetCore;
+
     public static class RTC_CustomEngine
     {
         private static Dictionary<string, Type> name2TypeDico = new Dictionary<string, Type>();

--- a/Source/Libraries/CorruptCore/Corruption Engines/RTC_DistortionEngine.cs
+++ b/Source/Libraries/CorruptCore/Corruption Engines/RTC_DistortionEngine.cs
@@ -1,7 +1,7 @@
-﻿using RTCV.NetCore;
-
-namespace RTCV.CorruptCore
+﻿namespace RTCV.CorruptCore
 {
+    using RTCV.NetCore;
+
     public static class RTC_DistortionEngine
     {
         public static int Delay

--- a/Source/Libraries/CorruptCore/Corruption Engines/RTC_HellgenieEngine.cs
+++ b/Source/Libraries/CorruptCore/Corruption Engines/RTC_HellgenieEngine.cs
@@ -1,7 +1,7 @@
-﻿using RTCV.NetCore;
-
-namespace RTCV.CorruptCore
+﻿namespace RTCV.CorruptCore
 {
+    using RTCV.NetCore;
+
     public static class RTC_HellgenieEngine
     {
         public static ulong MinValue8Bit

--- a/Source/Libraries/CorruptCore/Corruption Engines/RTC_NightmareEngine.cs
+++ b/Source/Libraries/CorruptCore/Corruption Engines/RTC_NightmareEngine.cs
@@ -1,8 +1,8 @@
-﻿using System.Windows.Forms;
-using RTCV.NetCore;
-
-namespace RTCV.CorruptCore
+﻿namespace RTCV.CorruptCore
 {
+    using System.Windows.Forms;
+    using RTCV.NetCore;
+
     public static class RTC_NightmareEngine
     {
         public static NightmareAlgo Algo

--- a/Source/Libraries/CorruptCore/Corruption Engines/RTC_VectorEngine.cs
+++ b/Source/Libraries/CorruptCore/Corruption Engines/RTC_VectorEngine.cs
@@ -1,7 +1,7 @@
-﻿using RTCV.NetCore;
-
-namespace RTCV.CorruptCore
+﻿namespace RTCV.CorruptCore
 {
+    using RTCV.NetCore;
+
     public static class RTC_VectorEngine
     {
         public static string LimiterListHash

--- a/Source/Libraries/CorruptCore/Diff.cs
+++ b/Source/Libraries/CorruptCore/Diff.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Collections;
-using System.IO;
-using System.Text.RegularExpressions;
-
-namespace RTCV.CorruptCore
+﻿namespace RTCV.CorruptCore
 {
+    using System;
+    using System.Collections;
+    using System.IO;
+    using System.Text.RegularExpressions;
+
     //ALL OF THIS WAS OBTAINED HERE: http://www.mathertel.de/Diff/
 
     /// <summary>

--- a/Source/Libraries/CorruptCore/EventWarlock/EWConditionGroup.cs
+++ b/Source/Libraries/CorruptCore/EventWarlock/EWConditionGroup.cs
@@ -1,11 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace RTCV.CorruptCore.EventWarlock
 {
+    using System.Collections.Generic;
 
     //todo: make easier for the editor to access all the conditionals
     [System.Serializable]
@@ -14,7 +9,7 @@ namespace RTCV.CorruptCore.EventWarlock
         /// <summary>
         /// The list of conditionals
         /// </summary>
-        public List<EWConditional> Conditionals = new List<EWConditional>(2);//try to make it as small as possible
+        public List<EWConditional> Conditionals = new List<EWConditional>(2); //try to make it as small as possible
 
         /// <summary>
         /// Adds a conditional. If an operator wasn't set on the last conditional it is automatically assigned a QuestionOp.AND
@@ -23,7 +18,7 @@ namespace RTCV.CorruptCore.EventWarlock
         public void AddConditional(EWConditional w)
         {
             Conditionals.Add(w);
-            if(Conditionals.Count > 1 && Conditionals[Conditionals.Count-1].NextOp == QuestionOp.NONE)
+            if (Conditionals.Count > 1 && Conditionals[Conditionals.Count - 1].NextOp == QuestionOp.NONE)
             {
                 Conditionals[Conditionals.Count - 1].NextOp = QuestionOp.AND;
             }
@@ -47,7 +42,7 @@ namespace RTCV.CorruptCore.EventWarlock
                 if (next == QuestionOp.AND) {
                     res = res && Conditionals[j].Evaluate(grimoire);
                 }
-                else if(next == QuestionOp.OR)
+                else if (next == QuestionOp.OR)
                 {
                     res = res || Conditionals[j].Evaluate(grimoire);
                 }

--- a/Source/Libraries/CorruptCore/EventWarlock/EWConditional.cs
+++ b/Source/Libraries/CorruptCore/EventWarlock/EWConditional.cs
@@ -1,11 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace RTCV.CorruptCore.EventWarlock
 {
+    using System;
+
     [Serializable]
     public abstract class EWConditional
     {

--- a/Source/Libraries/CorruptCore/EventWarlock/Editor/WarlockEditableAttribute.cs
+++ b/Source/Libraries/CorruptCore/EventWarlock/Editor/WarlockEditableAttribute.cs
@@ -1,11 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace RTCV.CorruptCore.EventWarlock.Editor
 {
+    using System;
+
     /// <summary>
     /// Used to link parameters to constructor arguments for the editor
     /// </summary>

--- a/Source/Libraries/CorruptCore/EventWarlock/Editor/WarlockEditorFieldAttribute.cs
+++ b/Source/Libraries/CorruptCore/EventWarlock/Editor/WarlockEditorFieldAttribute.cs
@@ -1,11 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace RTCV.CorruptCore.EventWarlock.Editor
 {
+    using System;
+
     /// <summary>
     /// Used to link parameters to constructor arguments for the editor
     /// </summary>

--- a/Source/Libraries/CorruptCore/EventWarlock/Grimoire.cs
+++ b/Source/Libraries/CorruptCore/EventWarlock/Grimoire.cs
@@ -1,12 +1,8 @@
-using RTCV.CorruptCore.EventWarlock;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace RTCV.CorruptCore.EventWarlock
 {
+    using System;
+    using System.Collections.Generic;
+
     [System.Serializable]
     public class Grimoire
     {
@@ -72,6 +68,5 @@ namespace RTCV.CorruptCore.EventWarlock
             SmallifyList(ExecuteSpells);
             SmallifyList(PostExecuteSpells);
         }
-
     }
 }

--- a/Source/Libraries/CorruptCore/EventWarlock/QuestionOp.cs
+++ b/Source/Libraries/CorruptCore/EventWarlock/QuestionOp.cs
@@ -1,11 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace RTCV.CorruptCore.EventWarlock
 {
+    using System;
+
     [Serializable]
     public enum QuestionOp
     {

--- a/Source/Libraries/CorruptCore/EventWarlock/Spell.cs
+++ b/Source/Libraries/CorruptCore/EventWarlock/Spell.cs
@@ -1,11 +1,11 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace RTCV.CorruptCore.EventWarlock
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
     /// <summary>
     /// Holds conditionals and actions to be executed if conditionals evaluates to true
     /// </summary>

--- a/Source/Libraries/CorruptCore/EventWarlock/Warlock.cs
+++ b/Source/Libraries/CorruptCore/EventWarlock/Warlock.cs
@@ -1,22 +1,16 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.Serialization;
-using System.Runtime.Serialization.Formatters.Binary;
-using System.Text;
-using System.Threading.Tasks;
-using RTCV.CorruptCore.Coroutines;
-
 namespace RTCV.CorruptCore.EventWarlock
 {
+    using System.Collections.Generic;
+    using System.Linq;
+    using RTCV.CorruptCore.Coroutines;
+
     /// <summary>
     /// I'm a wizard?? If you rename this you can't see the magic
     /// </summary>
     public static class Warlock
     {
         /// <summary>
-        /// The list of grimoires 
+        /// The list of grimoires
         /// </summary>
         private static List<Grimoire> Grimoires = new List<Grimoire>();
 
@@ -37,7 +31,7 @@ namespace RTCV.CorruptCore.EventWarlock
         /// <returns></returns>
         public static bool AddGrimoire(Grimoire grimoire)
         {
-            if(grimoire.Name != "" && Grimoires.Any(x => x.Name == grimoire.Name))
+            if (grimoire.Name != "" && Grimoires.Any(x => x.Name == grimoire.Name))
             {
                 //Grimoire name already taken
                 return false;
@@ -103,8 +97,8 @@ namespace RTCV.CorruptCore.EventWarlock
         {
             for (int j = 0; j < Grimoires.Count; j++)
             {
-                ExecuteList(Grimoires[j], Grimoires[j].LoadSpells); 
-            }          
+                ExecuteList(Grimoires[j], Grimoires[j].LoadSpells);
+            }
         }
 
         public static void PreExecute()

--- a/Source/Libraries/CorruptCore/EventWarlock/WarlockAction.cs
+++ b/Source/Libraries/CorruptCore/EventWarlock/WarlockAction.cs
@@ -1,11 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace RTCV.CorruptCore.EventWarlock
 {
+    using System;
 
     /// <summary>
     /// All subclasses must be serializable

--- a/Source/Libraries/CorruptCore/EventWarlock/WarlockActions/WarlockActionEcho.cs
+++ b/Source/Libraries/CorruptCore/EventWarlock/WarlockActions/WarlockActionEcho.cs
@@ -1,12 +1,8 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using RTCV.CorruptCore.EventWarlock.Editor;
-
 namespace RTCV.CorruptCore.EventWarlock.WarlockActions
 {
+    using System;
+    using RTCV.CorruptCore.EventWarlock.Editor;
+
     /// <summary>
     /// Example action
     /// </summary>

--- a/Source/Libraries/CorruptCore/EventWarlock/WarlockConditions/FirstEqualsSecond.cs
+++ b/Source/Libraries/CorruptCore/EventWarlock/WarlockConditions/FirstEqualsSecond.cs
@@ -1,13 +1,9 @@
-using RTCV.CorruptCore.EventWarlock;
-using RTCV.CorruptCore.EventWarlock.Editor;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace RTCV.CorruptCore.EventWarlock.WarlockConditions
 {
+    using System;
+    using RTCV.CorruptCore.EventWarlock;
+    using RTCV.CorruptCore.EventWarlock.Editor;
+
     /// <summary>
     /// Example conditional
     /// </summary>

--- a/Source/Libraries/CorruptCore/Filtering.cs
+++ b/Source/Libraries/CorruptCore/Filtering.cs
@@ -1,17 +1,15 @@
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Security.Cryptography;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-using RTCV.Common;
-using RTCV.NetCore;
-
-namespace RTCV.CorruptCore
+﻿namespace RTCV.CorruptCore
 {
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using System.Windows.Forms;
+    using RTCV.Common;
+    using RTCV.NetCore;
+
     public static class Filtering
     {
         private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
@@ -389,7 +387,7 @@ namespace RTCV.CorruptCore
                     Hash2NameDico.TryGetValue(s, out string name); //See if we can get the name
                     if (string.IsNullOrWhiteSpace(name))
                     {
-                        name = "UNKNOWN_" + s.Substring(0, 5); // Default name will use the first 5 chars of the hash 
+                        name = "UNKNOWN_" + s.Substring(0, 5); // Default name will use the first 5 chars of the hash
                     }
 
                     lists[(name.StartsWith("STOCKPILE_") ? "" : "STOCKPILE_") + name] = strList;

--- a/Source/Libraries/CorruptCore/Filtering.cs
+++ b/Source/Libraries/CorruptCore/Filtering.cs
@@ -141,7 +141,6 @@
             }
             else
             {
-
                 //detect what kind of list it is
                 if (temp.FirstOrDefault(it => it.Contains("?")) != null) //has wildcards, needs nullable array
                 {
@@ -157,12 +156,11 @@
             {
                 return list.Initialize(path, temp, flipBytes,syncListViaNetcore);
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 logger.Error(ex);
                 return "";
             }
-
         }
 
         /// <summary>
@@ -275,27 +273,26 @@
         {
             //checks nullable bytes lists against other byte lists, ignoring null collisions from both sides.
 
-            foreach(var item in hs.ToArray())
+            foreach (var item in hs.ToArray())
             {
                 bool found = true;
 
-                for(int i = 0; i<item.Length;i++)
+                for (int i = 0; i<item.Length; i++)
                 {
                     if (item[i] == null) //ignoring wildcards (null values)
                         continue;
 
-                    if(item[i].Value != bytes[i])
+                    if (item[i].Value != bytes[i])
                     {
                         found = false;
                         break;
                     }
                 }
 
-                if(found)
+                if (found)
                 {
                     return true;
                 }
-
             }
 
             return false;
@@ -320,7 +317,6 @@
             }
 
             return Hash2ValueDico[hash].GetPrecision();
-
         }
 
         /// <summary>
@@ -346,7 +342,6 @@
             var list = Hash2ValueDico[hash];
 
             return list.GetRandomValue(hash,precision);
-
         }
 
         /// <summary>
@@ -380,7 +375,6 @@
                 //If we have a value and the dictionary contains it, build up a String[] containing the values
                 if (s != null && Hash2LimiterDico.ContainsKey(s))
                 {
-
                     List<String> strList = Hash2LimiterDico[s].GetStringList();
 
 

--- a/Source/Libraries/CorruptCore/ListFilters.cs
+++ b/Source/Libraries/CorruptCore/ListFilters.cs
@@ -1,15 +1,13 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Security.Cryptography;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-using Ceras;
-
 namespace RTCV.CorruptCore
 {
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Security.Cryptography;
+    using System.Text;
+    using System.Windows.Forms;
+    using Ceras;
 
     public interface IListFilter
     {
@@ -21,7 +19,6 @@ namespace RTCV.CorruptCore
         public List<string> GetStringList();
 
         public int GetPrecision();
-
     }
 
     [Serializable]
@@ -74,8 +71,6 @@ namespace RTCV.CorruptCore
             string hash = Filtering.RegisterList(this, name, syncListViaNetcore);
 
             return hash;
-
-
         }
         public string GetHash()
         {
@@ -97,7 +92,6 @@ namespace RTCV.CorruptCore
         }
         public byte[] GetRandomValue(string hash, int precision)
         {
-
             //Get a random line in the list and grab the value
             int line = RtcCore.RND.Next(byteList.Count);
             byte[] value = byteList[line];
@@ -209,7 +203,6 @@ namespace RTCV.CorruptCore
             Filtering.RegisterList(this, name, syncListViaNetcore);
 
             return hash;
-
         }
         public string GetHash()
         {
@@ -231,7 +224,6 @@ namespace RTCV.CorruptCore
         }
         public byte[] GetRandomValue(string hash, int precision)
         {
-
             //Get a random line in the list and grab the value
             int line = RtcCore.RND.Next(byteList.Count);
             byte?[] value = byteList[line];
@@ -298,5 +290,4 @@ namespace RTCV.CorruptCore
             return value.Length;
         }
     }
-
 }

--- a/Source/Libraries/CorruptCore/MemoryBanks.cs
+++ b/Source/Libraries/CorruptCore/MemoryBanks.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.IO;
-
-namespace RTCV.CorruptCore
+﻿namespace RTCV.CorruptCore
 {
+    using System;
+    using System.IO;
+
     internal static class MemoryBanks
     {
         private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();

--- a/Source/Libraries/CorruptCore/MemoryDomains.cs
+++ b/Source/Libraries/CorruptCore/MemoryDomains.cs
@@ -1,18 +1,18 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.IO.Compression;
-using System.Linq;
-using System.Runtime.Serialization.Formatters.Binary;
-using System.Text;
-using System.Windows.Forms;
-using System.Xml.Serialization;
-using Ceras;
-using Newtonsoft.Json;
-using RTCV.NetCore;
-
 namespace RTCV.CorruptCore
 {
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.IO.Compression;
+    using System.Linq;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using System.Text;
+    using System.Windows.Forms;
+    using System.Xml.Serialization;
+    using Ceras;
+    using Newtonsoft.Json;
+    using RTCV.NetCore;
+
     public static class MemoryDomains
     {
         private static object miLock = new object();
@@ -1480,7 +1480,6 @@ namespace RTCV.CorruptCore
                 for (int i = 0; i < data.Length; i++)
                     lastMemoryDump[address + i] = data[i];
             */
-
         }
 
         public override void PokeByte(long address, byte data)
@@ -1867,7 +1866,6 @@ namespace RTCV.CorruptCore
         */
 
             //return lastMemoryDump;
-
         }
 
         public override byte[][] lastMemoryDump

--- a/Source/Libraries/CorruptCore/Objects.cs
+++ b/Source/Libraries/CorruptCore/Objects.cs
@@ -1,25 +1,23 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Diagnostics;
-using System.IO;
-using System.IO.Compression;
-using System.Linq;
-using System.Numerics;
-using System.Security.Cryptography;
-using System.Text;
-using System.Windows.Forms;
-using System.Xml.Serialization;
-using Ceras;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using RTCV.Common.Objects;
-using RTCV.NetCore;
-using Exception = System.Exception;
-
 namespace RTCV.CorruptCore
 {
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Data;
+    using System.Diagnostics;
+    using System.IO;
+    using System.IO.Compression;
+    using System.Linq;
+    using System.Numerics;
+    using System.Windows.Forms;
+    using System.Xml.Serialization;
+    using Ceras;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using RTCV.Common.Objects;
+    using RTCV.NetCore;
+    using Exception = System.Exception;
+
     [Serializable]
     [Ceras.MemberConfig(TargetMember.All)]
     public class Stockpile
@@ -188,7 +186,7 @@ namespace RTCV.CorruptCore
                         //If the file already exists, overwrite it.
                         if (File.Exists(romTempfilename))
                         {
-                            //Whack the attributes in case a rom is readonly 
+                            //Whack the attributes in case a rom is readonly
                             File.SetAttributes(romTempfilename, FileAttributes.Normal);
                             File.Delete(romTempfilename);
                             File.Copy(rom, romTempfilename);
@@ -361,7 +359,7 @@ namespace RTCV.CorruptCore
                 }
             }
 
-            //Update savestate location info 
+            //Update savestate location info
             percentPerFile = (5m) / (sks.StashKeys.Count + 1);
             foreach (StashKey sk in sks.StashKeys)
             {
@@ -594,13 +592,13 @@ namespace RTCV.CorruptCore
         }
 
         /// <summary>
-		/// Extracts a stockpile into a folder and ensures a master file exists
-		/// </summary>
-		/// <param name="filename"></param>
-		/// <param name="folder"></param>
-		/// <param name="masterFile"></param>
-		/// <returns></returns>
-		public static OperationResults<bool> Extract(string filename, string folder, string masterFile)
+        /// Extracts a stockpile into a folder and ensures a master file exists
+        /// </summary>
+        /// <param name="filename"></param>
+        /// <param name="folder"></param>
+        /// <param name="masterFile"></param>
+        /// <returns></returns>
+        public static OperationResults<bool> Extract(string filename, string folder, string masterFile)
         {
             var r = new OperationResults<bool>();
             try
@@ -861,7 +859,7 @@ namespace RTCV.CorruptCore
         /// <summary>
         /// Can be called from UI Side
         /// </summary>
-		public bool Run()
+        public bool Run()
         {
             StockpileManager_UISide.CurrentStashkey = this;
             return StockpileManager_UISide.ApplyStashkey(this);
@@ -870,7 +868,7 @@ namespace RTCV.CorruptCore
         /// <summary>
         /// Can be called from UI Side
         /// </summary>
-		public void RunOriginal()
+        public void RunOriginal()
         {
             StockpileManager_UISide.CurrentStashkey = this;
             StockpileManager_UISide.OriginalFromStashkey(this);
@@ -1197,7 +1195,7 @@ namespace RTCV.CorruptCore
                 {
                     usedAddresses.Add(new ValueTuple<string, long>(bu.Domain, bu.Address));
                 }
-                else if(!bu.IsLocked)
+                else if (!bu.IsLocked)
                 {
                     Layer.Remove(bu);
                 }
@@ -1396,7 +1394,7 @@ namespace RTCV.CorruptCore
             }
             set
             {
-                //If there's no precision, use the length of the string rounded up 
+                //If there's no precision, use the length of the string rounded up
                 int p = this.Precision;
                 if (p == 0 && value.Length != 0)
                 {
@@ -1467,7 +1465,7 @@ namespace RTCV.CorruptCore
         public BlastUnitWorkingData Working;
 
         /// <summary>
-        /// Creates a Blastunit that utilizes a backup. 
+        /// Creates a Blastunit that utilizes a backup.
         /// </summary>
         /// <param name="storeType">The type of store</param>
         /// <param name="storeTime">The time of the store</param>
@@ -1743,7 +1741,7 @@ namespace RTCV.CorruptCore
             //We need to grab the value to freeze
             if (Source == BlastUnitSource.STORE && StoreTime == StoreTime.IMMEDIATE)
             {
-                //If it's one time, store the backup. Otherwise add it to the backup pool 
+                //If it's one time, store the backup. Otherwise add it to the backup pool
                 if (StoreType == StoreType.ONCE)
                 {
                     StoreBackup();
@@ -1769,7 +1767,7 @@ namespace RTCV.CorruptCore
         /// <summary>
         /// Executes (applies) a blastunit. This shouldn't be called manually.
         /// If you want to execute a blastunit, add it to the execution pool using Apply()
-        /// Returns false 
+        /// Returns false
         /// </summary>
         public ExecuteState Execute(bool UseRealtime = true)
         {
@@ -2021,12 +2019,12 @@ namespace RTCV.CorruptCore
         public BlastUnit GetBackup()
         {
             //TODO
-            //There's a todo here but I didn't leave a note please help someone tell me why there's a todo here oh god I'm the only one working on this code 
+            //There's a todo here but I didn't leave a note please help someone tell me why there's a todo here oh god I'm the only one working on this code
             return GetBakedUnit();
         }
 
         /// <summary>
-        /// Rerolls a blastunit and generates new values based on various params 
+        /// Rerolls a blastunit and generates new values based on various params
         /// </summary>
         public void Reroll()
         {
@@ -2052,7 +2050,7 @@ namespace RTCV.CorruptCore
                             return;
                         }
 
-                        //Generate a random value based on our precision. 
+                        //Generate a random value based on our precision.
                         //We use a BigInteger as we support arbitrary length, but we do use built in methods for 8,16,32 bit for performance reasons
                         BigInteger randomValue = 0;
                         if (RTC_CustomEngine.ValueSource == CustomValueSource.RANGE)
@@ -2117,7 +2115,7 @@ namespace RTCV.CorruptCore
                     }
                     else
                     {
-                        //Generate a random value based on our precision. 
+                        //Generate a random value based on our precision.
                         //We use a BigInteger as we support arbitrary length, but we do use built in methods for 8,16,32 bit for performance reasons
                         BigInteger randomValue;
                         switch (Precision)

--- a/Source/Libraries/CorruptCore/Objects.cs
+++ b/Source/Libraries/CorruptCore/Objects.cs
@@ -919,7 +919,7 @@ namespace RTCV.CorruptCore
         //Todo - Replace this when compat is broken
         public void PopulateKnownLists()
         {
-            if(BlastLayer.Layer == null){
+            if (BlastLayer.Layer == null) {
                 MessageBox.Show($"Something went really wrong. Stashkey {Alias}.\nThere doesn't appear to be a linked blastlayer.\nWill attempt to continue saving. If save fails, remove {Alias} from your stockpile and save again.\nSend this stockpile and any info on how you got into this state to the devs.");
                 return;
             }
@@ -1039,9 +1039,8 @@ namespace RTCV.CorruptCore
                 StockpileManager_EmuSide.UnCorruptBL = GetBackup();
                 StockpileManager_EmuSide.CorruptBL = this;
 
-                if(mergeWithPrevious)
+                if (mergeWithPrevious)
                 {
-
                     if (UnCorruptBL_Backup.Layer != null)
                     {
                         if (StockpileManager_EmuSide.UnCorruptBL.Layer == null)

--- a/Source/Libraries/CorruptCore/Properties/AssemblyInfo.cs
+++ b/Source/Libraries/CorruptCore/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("CorruptCore")]
@@ -13,8 +13,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -24,11 +24,11 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]

--- a/Source/Libraries/CorruptCore/Render.cs
+++ b/Source/Libraries/CorruptCore/Render.cs
@@ -1,8 +1,8 @@
-﻿using System.Windows.Forms;
-using RTCV.NetCore;
-
-namespace RTCV.CorruptCore
+﻿namespace RTCV.CorruptCore
 {
+    using System.Windows.Forms;
+    using RTCV.NetCore;
+
     public static class Render
     {
         public static bool RenderAtLoad

--- a/Source/Libraries/CorruptCore/StepActions.cs
+++ b/Source/Libraries/CorruptCore/StepActions.cs
@@ -1,12 +1,11 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Windows.Forms;
-using RTCV.NetCore;
-using RTCV.Common;
-
 namespace RTCV.CorruptCore
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Windows.Forms;
+    using RTCV.NetCore;
+
     ///Rather than handling everything individually, we have a system here that works on collections of Blastunits
     ///In most usage, you're probably only going to have a small number of different lifetime/start time mixtures
     ///Rather than operating on every unit individually, we place everything into collections of Blastunits and then operate on them
@@ -170,9 +169,9 @@ namespace RTCV.CorruptCore
 
 
         /*
-		 Iterate over all the existing batches.
-		 If a batch that matches all the params already exists, return that. otherwise, create and return a new batch.
-		 */
+         Iterate over all the existing batches.
+         If a batch that matches all the params already exists, return that. otherwise, create and return a new batch.
+         */
         public static List<BlastUnit> GetBatchedLayer(BlastUnit bu)
         {
             List<BlastUnit> collection = null;
@@ -192,7 +191,7 @@ namespace RTCV.CorruptCore
             //Checks that the limiters match
             bool CheckLimitersMatch(BlastUnit bu1, BlastUnit bu2)
             {
-                //We only care if it's pre-execute because otherwise its limiter is independent from batching 
+                //We only care if it's pre-execute because otherwise its limiter is independent from batching
                 if (bu1.LimiterTime != LimiterTime.PREEXECUTE)
                 {
                     return true;
@@ -295,7 +294,7 @@ namespace RTCV.CorruptCore
                     queued.AddLast(buList);
                 }
 
-                //Nuke the list 
+                //Nuke the list
                 buListCollection = new List<List<BlastUnit>>();
 
                 //There's data so have the execute loop actually do something
@@ -329,7 +328,7 @@ namespace RTCV.CorruptCore
                 foreach (BlastUnit bu in buList)
                 {
                     //If it returns false, that means the layer shouldn't apply
-                    //This is primarily for if a limiter returns false 
+                    //This is primarily for if a limiter returns false
                     //If this happens, we need to remove it from the pool and then return out
                     if (!bu.EnteringExecution())
                     {

--- a/Source/Libraries/CorruptCore/StockpileManager_EmuSide.cs
+++ b/Source/Libraries/CorruptCore/StockpileManager_EmuSide.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Windows.Forms;
-using RTCV.NetCore;
-
-namespace RTCV.CorruptCore
+﻿namespace RTCV.CorruptCore
 {
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Windows.Forms;
+    using RTCV.NetCore;
+
     public static class StockpileManager_EmuSide
     {
         public static BlastLayer CorruptBL = null;
@@ -227,7 +227,7 @@ namespace RTCV.CorruptCore
         //From Bizhawk
         public static byte[] DeInterleaveSMD(byte[] source)
         {
-            // SMD files are interleaved in pages of 16k, with the first 8k containing all 
+            // SMD files are interleaved in pages of 16k, with the first 8k containing all
             // odd bytes and the second 8k containing all even bytes.
             int size = source.Length;
             if (size > 0x400000)

--- a/Source/Libraries/CorruptCore/StockpileManager_UISide.cs
+++ b/Source/Libraries/CorruptCore/StockpileManager_UISide.cs
@@ -1,12 +1,12 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Windows.Forms;
-using RTCV.NetCore;
-
 namespace RTCV.CorruptCore
 {
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Windows.Forms;
+    using RTCV.NetCore;
+
     public static class StockpileManager_UISide
     {
         //Object references

--- a/Source/Libraries/CorruptCore/StockpileManager_UISide.cs
+++ b/Source/Libraries/CorruptCore/StockpileManager_UISide.cs
@@ -19,7 +19,7 @@ namespace RTCV.CorruptCore
 
         private static void PreApplyStashkey(bool _clearUnitsBeforeApply = true)
         {
-            if(_clearUnitsBeforeApply)
+            if (_clearUnitsBeforeApply)
                 LocalNetCoreRouter.Route(NetcoreCommands.CORRUPTCORE, NetcoreCommands.REMOTE_CLEARSTEPBLASTUNITS, null, true);
 
 

--- a/Source/Libraries/NetCore/Connector.cs
+++ b/Source/Libraries/NetCore/Connector.cs
@@ -1,9 +1,9 @@
-using System;
-using System.Linq;
-using System.Threading;
-
 namespace RTCV.NetCore
 {
+    using System;
+    using System.Linq;
+    using System.Threading;
+
     public class NetCoreConnector : IRoutable
     {
         private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
@@ -108,7 +108,8 @@ namespace RTCV.NetCore
                     {
                         Thread.Sleep(50);
                     }
-                }catch(Exception ex)
+                }
+                catch (Exception ex)
                 {
                     logger.Error(ex, "Something went terribly wrong when stopping tcp networking");
                 }

--- a/Source/Libraries/NetCore/DebugInfo/CloudDebug_Form.cs
+++ b/Source/Libraries/NetCore/DebugInfo/CloudDebug_Form.cs
@@ -1,17 +1,17 @@
-using System;
-using System.Data;
-using System.Diagnostics;
-using System.Drawing;
-using System.IO;
-using System.Net;
-using System.Reflection;
-using System.Runtime.Serialization.Formatters.Binary;
-using System.Text;
-using System.Windows.Forms;
-using RTCV.Common;
-
 namespace RTCV.NetCore
 {
+    using System;
+    using System.Data;
+    using System.Diagnostics;
+    using System.Drawing;
+    using System.IO;
+    using System.Net;
+    using System.Reflection;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using System.Text;
+    using System.Windows.Forms;
+    using RTCV.Common;
+
     public partial class CloudDebug : Form
     {
         private Exception ex;
@@ -239,7 +239,7 @@ namespace RTCV.NetCore
                     File.Delete(file);
                 }
 
-                
+
                 SevenZip.SevenZipCompressor.SetLibraryPath(szdll);
                 var decomp = new SevenZip.SevenZipExtractor(downloadfilepath, password, SevenZip.InArchiveFormat.SevenZip);
                 decomp.ExtractArchive(extractpath);

--- a/Source/Libraries/NetCore/DebugInfo/DebugInfo_Form.cs
+++ b/Source/Libraries/NetCore/DebugInfo/DebugInfo_Form.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Windows.Forms;
-
-namespace RTCV.NetCore
+﻿namespace RTCV.NetCore
 {
+    using System;
+    using System.Windows.Forms;
+
     public partial class DebugInfo_Form : Form
     {
         public DebugInfo_Form()
@@ -25,6 +25,5 @@ namespace RTCV.NetCore
         private void btnGetDebugRTC_Click(object sender, EventArgs e) => tbRTC.Text = CloudDebug.getRTCInfo();
 
         private void btnGetDebugEmu_Click(object sender, EventArgs e) => richTextBox2.Text = CloudDebug.getEmuInfo();
-
     }
 }

--- a/Source/Libraries/NetCore/LocalRouter.cs
+++ b/Source/Libraries/NetCore/LocalRouter.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Windows.Forms;
-
-namespace RTCV.NetCore
+﻿namespace RTCV.NetCore
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Windows.Forms;
+
     public static class LocalNetCoreRouter
     {
         private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();

--- a/Source/Libraries/NetCore/MessageHub.cs
+++ b/Source/Libraries/NetCore/MessageHub.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Timers;
-
-namespace RTCV.NetCore
+﻿namespace RTCV.NetCore
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Timers;
+
     public class MessageHub
     {
         private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
@@ -173,5 +173,3 @@ namespace RTCV.NetCore
         }
     }
 }
-
-

--- a/Source/Libraries/NetCore/NetCore.csproj
+++ b/Source/Libraries/NetCore/NetCore.csproj
@@ -43,7 +43,6 @@
     <PlatformTarget>x64</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>..\..\..\Build\</OutputPath>
@@ -52,7 +51,6 @@
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -126,7 +124,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/Source/Libraries/NetCore/NetCoreObjects.cs
+++ b/Source/Libraries/NetCore/NetCoreObjects.cs
@@ -1,12 +1,12 @@
-using System;
-using System.ComponentModel;
-using System.Reflection;
-using System.Threading;
-using System.Windows.Forms;
-using Ceras;
-
 namespace RTCV.NetCore
 {
+    using System;
+    using System.ComponentModel;
+    using System.Reflection;
+    using System.Threading;
+    using System.Windows.Forms;
+    using Ceras;
+
     public enum NetworkSide
     {
         NONE,

--- a/Source/Libraries/NetCore/NetCore_Extensions.cs
+++ b/Source/Libraries/NetCore/NetCore_Extensions.cs
@@ -1,22 +1,22 @@
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Reflection.Emit;
-using System.Runtime.ExceptionServices;
-using System.Runtime.InteropServices;
-using System.Runtime.Serialization.Formatters.Binary;
-using System.Text;
-using System.Threading;
-using System.Windows.Forms;
-using Ceras;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
-
 namespace RTCV.NetCore
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Linq;
+    using System.Reflection;
+    using System.Reflection.Emit;
+    using System.Runtime.ExceptionServices;
+    using System.Runtime.InteropServices;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using System.Text;
+    using System.Threading;
+    using System.Windows.Forms;
+    using Ceras;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Serialization;
+
     public static class NetCore_Extensions
     {
         public static class ObjectCopier

--- a/Source/Libraries/NetCore/Params.cs
+++ b/Source/Libraries/NetCore/Params.cs
@@ -1,7 +1,7 @@
-﻿using System.IO;
-
-namespace RTCV.NetCore
+﻿namespace RTCV.NetCore
 {
+    using System.IO;
+
     public static class Params
     {
         //Todo - Isolate this out

--- a/Source/Libraries/NetCore/Properties/AssemblyInfo.cs
+++ b/Source/Libraries/NetCore/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("NetCore")]
@@ -13,8 +13,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -24,11 +24,11 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("2.0.0.0")]

--- a/Source/Libraries/NetCore/ReturnWatch.cs
+++ b/Source/Libraries/NetCore/ReturnWatch.cs
@@ -1,12 +1,10 @@
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace RTCV.NetCore
 {
+    using System;
+    using System.Collections.Concurrent;
+    using System.Threading;
+    using System.Threading.Tasks;
+
     public class ReturnWatch
     {
         //This is a component that allows to freeze the thread that asked for a value from a Synced Message
@@ -21,7 +19,7 @@ namespace RTCV.NetCore
 
         public bool IsWaitingForReturn
         {
-            get 
+            get
             {
                 return activeWatches > 0;
             }
@@ -58,9 +56,9 @@ namespace RTCV.NetCore
             {
                 result = GetValueTask(WatchedGuid, type, cts.Token).Result;
             }
-            catch(Exception e)
+            catch (Exception e)
             {
-                if(e is OperationCanceledException
+                if (e is OperationCanceledException
                     || (e is AggregateException && (e.InnerException is OperationCanceledException || e.InnerException is TaskCanceledException)))
                 {
                     logger.Info("WatchedGuid {guid} was cancelled, returning null.", WatchedGuid);
@@ -74,6 +72,7 @@ namespace RTCV.NetCore
             return result;
         }
 
+        #pragma warning disable CS1998
         internal async Task<Object> GetValueTask(Guid WatchedGuid, string type, CancellationToken token)
         {
             token.ThrowIfCancellationRequested();

--- a/Source/Libraries/NetCore/SyncObjectSingleton.cs
+++ b/Source/Libraries/NetCore/SyncObjectSingleton.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Windows.Forms;
-
-namespace RTCV.NetCore
+﻿namespace RTCV.NetCore
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Windows.Forms;
+
     public static class SyncObjectSingleton
     {
         public static Form SyncObject;

--- a/Source/Libraries/NetCore/TCPLink.cs
+++ b/Source/Libraries/NetCore/TCPLink.cs
@@ -1,15 +1,15 @@
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Net;
-using System.Net.Sockets;
-using System.Runtime.Serialization;
-using System.Threading;
-using Ceras;
-
 namespace RTCV.NetCore
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Net;
+    using System.Net.Sockets;
+    using System.Runtime.Serialization;
+    using System.Threading;
+    using Ceras;
+
     public class TCPLink
     {
         private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();

--- a/Source/Libraries/NetCore/TCPLinkWatch.cs
+++ b/Source/Libraries/NetCore/TCPLinkWatch.cs
@@ -1,7 +1,7 @@
-﻿using System.Threading;
-
-namespace RTCV.NetCore
+﻿namespace RTCV.NetCore
 {
+    using System.Threading;
+
     public class TCPLinkWatch
     {
         private volatile System.Timers.Timer watchdog = null;

--- a/Source/Libraries/NetCore/UDPLink.cs
+++ b/Source/Libraries/NetCore/UDPLink.cs
@@ -1,11 +1,11 @@
-using System;
-using System.Net;
-using System.Net.Sockets;
-using System.Text;
-using System.Threading;
-
 namespace RTCV.NetCore
 {
+    using System;
+    using System.Net;
+    using System.Net.Sockets;
+    using System.Text;
+    using System.Threading;
+
     public class UDPLink
     {
         private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
@@ -54,7 +54,7 @@ namespace RTCV.NetCore
             {
                 byte[] sdata = Encoding.ASCII.GetBytes(message.Type);
                 Sender.Send(sdata, sdata.Length);
-                //Todo - Refactor this into a way to blacklist specific commands 
+                //Todo - Refactor this into a way to blacklist specific commands
                 if (message.Type != "UI|KILLSWITCH_PULSE" || ConsoleEx.ShowDebug)
                 {
                     logger.Trace("UDP : Sent simple message \"{type}\"", message.Type);

--- a/Source/Libraries/NetCore/UniSpec.cs
+++ b/Source/Libraries/NetCore/UniSpec.cs
@@ -1,17 +1,17 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.Serialization;
-using System.Text;
-using Ceras;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-
-namespace RTCV.NetCore
+﻿namespace RTCV.NetCore
 {
+    using System;
+    using System.Collections;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using System.Runtime.Serialization;
+    using System.Text;
+    using Ceras;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+
     public class FullSpec : BaseSpec
     {
         public event EventHandler<SpecUpdateEventArgs> SpecUpdated;
@@ -40,7 +40,7 @@ namespace RTCV.NetCore
             name = partialSpec.Name;
             Update(template);
 
-            //Set the version after the update 
+            //Set the version after the update
             if (partialSpec.version != 1)
             {
                 base.version = partialSpec.version;
@@ -106,20 +106,20 @@ namespace RTCV.NetCore
         public void Update(string key, object value, bool propagate = true, bool synced = true)
         {
             /*
-			//Make a partial spec and pass it into Update(PartialSpec)
-			if (RTC_NetcoreImplementation.isStandaloneEmu && name == "RTCSpec" && key != RTCSPEC.CORE_AUTOCORRUPT.ToString())
-				throw new Exception("Tried updating the RTCSpec from Emuhawk");
+            //Make a partial spec and pass it into Update(PartialSpec)
+            if (RTC_NetcoreImplementation.isStandaloneEmu && name == "RTCSpec" && key != RTCSPEC.CORE_AUTOCORRUPT.ToString())
+                throw new Exception("Tried updating the RTCSpec from Emuhawk");
 
-			if (RTC_NetcoreImplementation.isStandaloneUI && name == "EmuSpec")
-				throw new Exception("Tried updating the EmuSpec from StandaloneRTC");
-				*/
+            if (RTC_NetcoreImplementation.isStandaloneUI && name == "EmuSpec")
+                throw new Exception("Tried updating the EmuSpec from StandaloneRTC");
+                */
             /*
-			if(value is bool)
-			{
-				bool boolValue = (bool)value;
-				if (boolValue == false)
-					value = null;
-			}*/
+            if(value is bool)
+            {
+                bool boolValue = (bool)value;
+                if (boolValue == false)
+                    value = null;
+            }*/
 
             PartialSpec spec = new PartialSpec(name);
             spec[key] = value;
@@ -187,16 +187,16 @@ namespace RTCV.NetCore
                     sb.AppendLine(RecursiveEnumerate(_em, sb, tab + 1));
                 }
                 /*
-				if (x is KeyValuePair<string, List<Byte[]>> b)
-				{
-					b.Value.ForEach(y =>
-					{
-						foreach (var z in y)
-							sb.Append(z.ToString());
-						sb.Append("\n" + t + "\t");
-					});
-				}
-				*/
+                if (x is KeyValuePair<string, List<Byte[]>> b)
+                {
+                    b.Value.ForEach(y =>
+                    {
+                        foreach (var z in y)
+                            sb.Append(z.ToString());
+                        sb.Append("\n" + t + "\t");
+                    });
+                }
+                */
                 sb.AppendLine(t + x.ToString());
             }
             return sb.ToString();

--- a/Source/Libraries/PluginHost/Host.cs
+++ b/Source/Libraries/PluginHost/Host.cs
@@ -1,14 +1,13 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.Composition;
-using System.ComponentModel.Composition.Hosting;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using NLog;
-
 namespace RTCV.PluginHost
 {
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel.Composition;
+    using System.ComponentModel.Composition.Hosting;
+    using System.IO;
+    using System.Reflection;
+    using NLog;
+
     public class Host
     {
         [ImportMany(typeof(IPlugin))]
@@ -33,7 +32,7 @@ namespace RTCV.PluginHost
             var catalog = new AggregateCatalog();
             foreach (var dir in pluginDirs)
             {
-                if(Directory.Exists(dir))
+                if (Directory.Exists(dir))
                     catalog.Catalogs.Add(new DirectoryCatalog(dir));
             }
             _container = new CompositionContainer(catalog);
@@ -68,9 +67,9 @@ namespace RTCV.PluginHost
                     //Start both sides and leave it up to the plugin dev to handle it for now if they're devving in attached mode (sorry Narry) //Narry 3-22-20
                     if (side == RTCSide.Both)
                     {
-                        if(p.Start(RTCSide.Client))
+                        if (p.Start(RTCSide.Client))
                             logger.Info("Loaded {pluginName} as client successfully", p.Name);
-                        if(p.Start(RTCSide.Server))
+                        if (p.Start(RTCSide.Server))
                             logger.Info("Loaded {pluginName} as server successfully", p.Name);
                         _loadedPlugins.Add(p);
                     }
@@ -83,14 +82,13 @@ namespace RTCV.PluginHost
                     {
                         logger.Error("Failed to load {pluginName}", p.Name);
                     }
-
                 }
             }
             initialized = true;
         }
         public void Shutdown()
         {
-            foreach(var p in _loadedPlugins)
+            foreach (var p in _loadedPlugins)
             {
                 p.Stop();
             }

--- a/Source/Libraries/PluginHost/IPlugin.cs
+++ b/Source/Libraries/PluginHost/IPlugin.cs
@@ -1,7 +1,7 @@
-using System;
-
 namespace RTCV.PluginHost
 {
+    using System;
+
     public enum RTCSide
     {
         Server,

--- a/Source/Libraries/PluginHost/PluginHost.csproj
+++ b/Source/Libraries/PluginHost/PluginHost.csproj
@@ -34,7 +34,7 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="System.IO.Compression, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />

--- a/Source/Libraries/Vanguard/Objects.cs
+++ b/Source/Libraries/Vanguard/Objects.cs
@@ -1,8 +1,8 @@
-using System;
-using RTCV.NetCore;
-
 namespace RTCV.Vanguard
 {
+    using System;
+    using RTCV.NetCore;
+
     public class TargetSpec
     {
         public event EventHandler<NetCoreEventArgs> MessageReceived;

--- a/Source/Libraries/Vanguard/Properties/AssemblyInfo.cs
+++ b/Source/Libraries/Vanguard/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Vanguard")]
@@ -13,8 +13,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -24,11 +24,11 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]

--- a/Source/Libraries/Vanguard/Vanguard.csproj
+++ b/Source/Libraries/Vanguard/Vanguard.csproj
@@ -39,7 +39,6 @@
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>..\..\..\Build\</OutputPath>
@@ -48,7 +47,6 @@
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <PlatformTarget>x86</PlatformTarget>
@@ -84,7 +82,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/Source/Libraries/Vanguard/VanguardConnector.cs
+++ b/Source/Libraries/Vanguard/VanguardConnector.cs
@@ -1,11 +1,11 @@
-using System;
-using System.Linq;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-using NetworkSide = RTCV.NetCore.NetworkSide;
-
 namespace RTCV.Vanguard
 {
+    using System;
+    using System.Linq;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+    using NetworkSide = RTCV.NetCore.NetworkSide;
+
     public class VanguardConnector : IRoutable
     {
         public NetCoreReceiver receiver;

--- a/Source/Plugins/HexEditor/HexEditor.cs
+++ b/Source/Plugins/HexEditor/HexEditor.cs
@@ -1,21 +1,21 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-using RTCV.NetCore;
-using RTCV.CorruptCore;
-using NLog;
-using NLog.Layouts;
-
 namespace RTCV.Plugins.HexEditor
 {
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Data;
+    using System.Drawing;
+    using System.Globalization;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Windows.Forms;
+    using RTCV.NetCore;
+    using RTCV.CorruptCore;
+    using NLog;
+    using NLog.Layouts;
+
     //Based on the Hex Editor from Bizhawk, available under MIT.
     //https://github.com/tasvideos/bizhawk
     public partial class HexEditor : Form
@@ -106,7 +106,7 @@ namespace RTCV.Plugins.HexEditor
             };
             CorruptCore.RtcCore.LoadGameDone += (o, e) =>
             {
-                if(this.Visible)
+                if (this.Visible)
                     Restart();
             };
 
@@ -179,7 +179,7 @@ namespace RTCV.Plugins.HexEditor
                 }
                 catch (Exception e)
                 {
-                    logger.Error(e,"Failed to UpdateValues() in hex editor.");
+                    logger.Error(e, "Failed to UpdateValues() in hex editor.");
                 }
             }));
         }
@@ -2049,7 +2049,7 @@ namespace RTCV.Plugins.HexEditor
 
         private void FreezeAddress(long address)
         {
-            BlastUnit bu = new BlastUnit(StoreType.ONCE, StoreTime.IMMEDIATE, _domain.Name, address, _domain.Name, address, DataSize, _domain.BigEndian, 0, 0); ;
+            BlastUnit bu = new BlastUnit(StoreType.ONCE, StoreTime.IMMEDIATE, _domain.Name, address, _domain.Name, address, DataSize, _domain.BigEndian, 0, 0);
             bu.Apply(false);
         }
 

--- a/Source/Plugins/HexEditor/HexEditor.cs
+++ b/Source/Plugins/HexEditor/HexEditor.cs
@@ -23,7 +23,6 @@ namespace RTCV.Plugins.HexEditor
         private int fontWidth;
         private int fontHeight;
 
-        private readonly List<ToolStripMenuItem> _domainMenuItems = new List<ToolStripMenuItem>();
         private readonly char[] _nibbles = { 'G', 'G', 'G', 'G', 'G', 'G', 'G', 'G' };    // G = off 0-9 & A-F are acceptable values
         private readonly List<long> _secondaryHighlightedAddresses = new List<long>();
 
@@ -165,8 +164,6 @@ namespace RTCV.Plugins.HexEditor
         {
             return true;
         }
-
-        private volatile object updateValuesSyncObject = new object();
 
         public async void UpdateValues()
         {

--- a/Source/Plugins/HexEditor/HexFind.cs
+++ b/Source/Plugins/HexEditor/HexFind.cs
@@ -1,11 +1,11 @@
-using System;
-using System.Drawing;
-using System.Text;
-using System.Windows.Forms;
-using RTCV.Common;
-
 namespace RTCV.Plugins.HexEditor
 {
+    using System;
+    using System.Drawing;
+    using System.Text;
+    using System.Windows.Forms;
+    using RTCV.Common;
+
     public partial class HexFind : Form
     {
         public HexFind()

--- a/Source/Plugins/HexEditor/HexTextBox.cs
+++ b/Source/Plugins/HexEditor/HexTextBox.cs
@@ -1,12 +1,12 @@
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Windows.Forms;
-
 namespace RTCV.Plugins.HexEditor
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Text;
+    using System.Windows.Forms;
+
     public interface INumberBox
     {
         bool Nullable { get; }

--- a/Source/Plugins/HexEditor/InputPrompt.cs
+++ b/Source/Plugins/HexEditor/InputPrompt.cs
@@ -1,10 +1,10 @@
-using System;
-using System.Drawing;
-using System.Linq;
-using System.Windows.Forms;
-
 namespace RTCV.Plugins.HexEditor
 {
+    using System;
+    using System.Drawing;
+    using System.Linq;
+    using System.Windows.Forms;
+
     /// <summary>
     /// A simple form that prompts the user for a single line of input.
     /// Supports multiline messages

--- a/Source/Plugins/HexEditor/Loader.cs
+++ b/Source/Plugins/HexEditor/Loader.cs
@@ -1,13 +1,13 @@
-using System;
-using System.ComponentModel.Composition;
-using NLog;
-using RTCV.Common;
-using RTCV.PluginHost;
-using RTCV.NetCore;
-using System.Windows.Forms;
-
 namespace RTCV.Plugins.HexEditor
 {
+    using System;
+    using System.ComponentModel.Composition;
+    using System.Windows.Forms;
+    using NLog;
+    using RTCV.Common;
+    using RTCV.PluginHost;
+    using RTCV.NetCore;
+
     [Export(typeof(IPlugin))]
     public class Loader : IPlugin
     {

--- a/Source/Plugins/HexEditor/VanguardConnector.cs
+++ b/Source/Plugins/HexEditor/VanguardConnector.cs
@@ -1,9 +1,9 @@
-using RTCV.Common;
-using RTCV.CorruptCore;
-using RTCV.NetCore;
-
 namespace RTCV.Plugins.HexEditor
 {
+    using RTCV.Common;
+    using RTCV.CorruptCore;
+    using RTCV.NetCore;
+
     public class HexEditorConnector : IRoutable
     {
         public HexEditorConnector()
@@ -58,5 +58,5 @@ namespace RTCV.Plugins.HexEditor
             }
             return e.returnMessage;
         }
-    } 
+    }
 }

--- a/Source/Plugins/ScriptHost/Controls/ScriptManager.cs
+++ b/Source/Plugins/ScriptHost/Controls/ScriptManager.cs
@@ -1,16 +1,16 @@
-using System;
-using System.Drawing;
-using System.IO;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-using CSScriptLibrary;
-using NLog;
-using NLog.Layouts;
-using NLog.Windows.Forms;
-using ScintillaNET;
-
 namespace RTCV.Plugins.ScriptHost.Controls
 {
+    using System;
+    using System.Drawing;
+    using System.IO;
+    using System.Threading.Tasks;
+    using System.Windows.Forms;
+    using CSScriptLibrary;
+    using NLog;
+    using NLog.Layouts;
+    using NLog.Windows.Forms;
+    using ScintillaNET;
+
     public partial class ScriptManager : UserControl
     {
         Logger _logger = null;
@@ -32,7 +32,6 @@ namespace RTCV.Plugins.ScriptHost.Controls
                     MaxLines = 10000,
                     AutoScroll = true,
                     UseDefaultRowColoringRules = false,
-
                 };
                 logtextbox.RowColoringRules.Add(new RichTextBoxRowColoringRule(
                         "level == LogLevel.Trace", // condition
@@ -74,7 +73,7 @@ namespace RTCV.Plugins.ScriptHost.Controls
         {
             InitializeComponent();
             //CSScript.EvaluatorConfig.Engine = EvaluatorEngine.Roslyn;
-            if(darkTheme)
+            if (darkTheme)
                 ConfigureScintillaDark();
             else
             {
@@ -205,7 +204,7 @@ namespace RTCV.Plugins.ScriptHost.Controls
             MethodDelegate scr = null;
             try
             {
-                scr = await Task.Run(() =>CSScript.CodeDomEvaluator.CreateDelegate(scintilla.Text));
+                scr = await Task.Run(() => CSScript.CodeDomEvaluator.CreateDelegate(scintilla.Text));
             }
             catch (Exception ex)
             {

--- a/Source/Plugins/ScriptHost/Controls/ScriptManagerTab.cs
+++ b/Source/Plugins/ScriptHost/Controls/ScriptManagerTab.cs
@@ -1,13 +1,13 @@
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Manina.Windows.Forms;
-
 namespace RTCV.Plugins.ScriptHost.Controls
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Drawing;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Manina.Windows.Forms;
+
     sealed class ScriptManagerTab : Tab
     {
         public ScriptManager ScriptManager;

--- a/Source/Plugins/ScriptHost/Loader.cs
+++ b/Source/Plugins/ScriptHost/Loader.cs
@@ -1,14 +1,13 @@
-using System;
-using System.ComponentModel.Composition;
-using NLog;
-using RTCV.Common;
-using RTCV.PluginHost;
-using RTCV.Plugins.ScriptHost.Controls;
-using RTCV.UI;
-
-
 namespace RTCV.Plugins.ScriptHost
 {
+    using System;
+    using System.ComponentModel.Composition;
+    using NLog;
+    using RTCV.Common;
+    using RTCV.PluginHost;
+    using RTCV.Plugins.ScriptHost.Controls;
+    using RTCV.UI;
+
     [Export(typeof(IPlugin))]
     public class Loader : IPlugin
     {

--- a/Source/Plugins/ScriptHost/ScriptHost.cs
+++ b/Source/Plugins/ScriptHost/ScriptHost.cs
@@ -1,13 +1,13 @@
-using System;
-using System.Drawing;
-using System.IO;
-using System.Linq;
-using System.Windows.Forms;
-using NLog;
-using RTCV.Plugins.ScriptHost.Controls;
-
 namespace RTCV.Plugins.ScriptHost
 {
+    using System;
+    using System.Drawing;
+    using System.IO;
+    using System.Linq;
+    using System.Windows.Forms;
+    using NLog;
+    using RTCV.Plugins.ScriptHost.Controls;
+
     public partial class ScriptHost : Form
     {
         Color DarkerGray = Color.FromArgb(64, 64, 64);

--- a/Source/Plugins/ScriptHost/ScriptHost.cs
+++ b/Source/Plugins/ScriptHost/ScriptHost.cs
@@ -10,7 +10,6 @@ namespace RTCV.Plugins.ScriptHost
 
     public partial class ScriptHost : Form
     {
-        Color DarkerGray = Color.FromArgb(64, 64, 64);
         public ScriptHost()
         {
             InitializeComponent();

--- a/Source/Plugins/TestPlugin/TestPlugin.cs
+++ b/Source/Plugins/TestPlugin/TestPlugin.cs
@@ -1,12 +1,12 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.Composition;
-using System.Text;
-using System.Threading.Tasks;
-using RTCV.PluginHost;
-
 namespace RTCV.Plugins
 {
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel.Composition;
+    using System.Text;
+    using System.Threading.Tasks;
+    using RTCV.PluginHost;
+
     [Export(typeof(IPlugin))]
     public class TestPlugin : IPlugin
     {

--- a/Source/Prereqs/PrereqChecker/PrereqChecker.csproj
+++ b/Source/Prereqs/PrereqChecker/PrereqChecker.csproj
@@ -19,7 +19,6 @@
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
     <WarningLevel>3</WarningLevel>
   </PropertyGroup>
@@ -30,7 +29,6 @@
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
@@ -40,7 +38,6 @@
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
@@ -50,7 +47,6 @@
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>

--- a/Source/Tests/TestVanguardImplemented/VanguardCore.cs
+++ b/Source/Tests/TestVanguardImplemented/VanguardCore.cs
@@ -19,7 +19,7 @@ namespace TestVanguardImplemented
 	public static class VanguardCore
 	{
 		public static string[] args;
-		
+
 
 		internal static DialogResult ShowErrorDialog(Exception exception, bool canContinue = false)
 		{
@@ -28,7 +28,7 @@ namespace TestVanguardImplemented
 
 
 		/// <summary>
-		/// Global exceptions in Non User Interfarce(other thread) antipicated error
+		/// Global exceptions in Non User Interface(other thread) anticipated error
 		/// </summary>
 		/// <param name="sender"></param>
 		/// <param name="e"></param>
@@ -41,7 +41,7 @@ namespace TestVanguardImplemented
 		}
 
 		/// <summary>
-		/// Global exceptions in User Interfarce antipicated error
+		/// Global exceptions in User Interface anticipated error
 		/// </summary>
 		/// <param name="sender"></param>
 		/// <param name="e"></param>
@@ -301,7 +301,7 @@ namespace TestVanguardImplemented
 		}
 
 		/// <summary>
-		/// Loads a savestate from a path. 
+		/// Loads a savestate from a path.
 		/// </summary>
 		/// <param name="path">The path of the state</param>
 		/// <param name="stateLocation">Where the state is located in a stashkey (used for errors, not required)</param>

--- a/StyleCop.ruleset
+++ b/StyleCop.ruleset
@@ -82,46 +82,65 @@
     <Rule Id="SA1130" Action="None" /> <!-- Use lambda syntax -->
   </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.FxCopAnalyzers" RuleNamespace="Microsoft.CodeAnalysis.FxCopAnalyzers">
+    <Rule Id="CS0649" Action="None" /> <!-- Field never assigned to -->
     <Rule Id="CA2000" Action="None" /> <!-- Call on object before all references to it are out of scope -->
     <Rule Id="CA2002" Action="None" /> <!-- Do not lock on objects with weak identity -->
     <Rule Id="CA2007" Action="None" /> <!-- Call ConfigureAwait on the awaited task -->
+    <Rule Id="CA2008" Action="None" /> <!-- No tasks without a TaskScheduler -->
+    <Rule Id="CA1001" Action="None" /> <!-- Class owns disposable fields but is not disposable -->
+    <Rule Id="CA1028" Action="None" /> <!-- If possible, make the underlying type of FileType System.Int32 instead of uint -->
+    <Rule Id="CA1032" Action="None" /> <!-- Add constructor to class -->
     <Rule Id="CA1040" Action="None" /> <!-- Avoid empty interfaces -->
     <Rule Id="CA1060" Action="None" /> <!-- Move pinvokes to native methods class -->
+    <Rule Id="CA1065" Action="None" /> <!-- Method creates exception -->
     <Rule Id="CA1303" Action="None" /> <!-- Passing literal string as parameter -->
     <Rule Id="CA1822" Action="None" /> <!-- Member can be marked as static -->
     <Rule Id="CA2101" Action="None" /> <!--  Specify marshaling for P/Invoke string arguments -->
+    <Rule Id="CA2200" Action="None" /> <!-- Re-throwing caught exception changes stack information -->
     <Rule Id="CA2208" Action="None" /> <!-- Method passes parameter as the message argument -->
     <Rule Id="CA2211" Action="None" /> <!-- Non-constant fields should not be visible -->
     <Rule Id="CA2213" Action="None" /> <!-- Change Dispore method to call Close or Dispose -->
     <Rule Id="CA2227" Action="None" /> <!-- Change to be read-only by removing the property setter -->
+    <Rule Id="CA2234" Action="None" /> <!-- Call a different method -->
+    <Rule Id="CA2237" Action="None" /> <!-- Add [Serializable] to class -->
     <Rule Id="CA1724" Action="None" /> <!-- Naming conflict -->
     <Rule Id="CA1051" Action="None" /> <!-- Do not declare visible instance fields -->
     <Rule Id="CA1304" Action="None" /> <!-- string.ToUpper behavior could vary based on the current user's locale settings -->
     <Rule Id="CA1305" Action="None" /> <!-- String parsing behavior could vary based on the current user's locale settings -->
     <Rule Id="CA1307" Action="None" /> <!-- string.EndsWith behavior could vary based on the current user's locale settings -->
     <Rule Id="CA1034" Action="None" /> <!-- Do not nest type -->
+    <Rule Id="CA1052" Action="None" /> <!--Type is a static holder type but is neither static nor NotInheritable -->
     <Rule Id="CA1401" Action="None" />
     <Rule Id="CA1062" Action="None" /> <!-- Validate parameters for externally visible methods -->
     <Rule Id="CA1063" Action="None" />
+    <Rule Id="CA1066" Action="None" /> <!-- Implement IEquatable when overriding Object.Equals -->
+    <Rule Id="CA1810" Action="None" /> <!-- Remove the explicit static constructor -->
     <Rule Id="CA1016" Action="None" /> <!-- Mark assemblies with assembly version -->
+    <Rule Id="CA1507" Action="None" /> <!-- Use nameof in place of string literal -->
     <Rule Id="CA1707" Action="None" /> <!-- Remove underscore for member name -->
+    <Rule Id="CA1712" Action="None" /> <!-- Do not prefix enum values with the name of the enum type 'FileType' -->
     <Rule Id="CA1714" Action="None" /> <!-- Flags enums should have plural names -->
     <Rule Id="CA1715" Action="None" /> <!-- Prefix generic type parameter name with 'T' -->
+    <Rule Id="CA1717" Action="None" /> <!-- Only FlagsAttribute enums should have plural names -->
     <Rule Id="CA1801" Action="None" /> <!-- Parameter list of method is never used. Remove the parameter or use it in the method body -->
     <Rule Id="CA1802" Action="None" /> <!-- readonly field should be const -->
     <Rule Id="CA1806" Action="None" /> <!-- Using method without reference to error -->
+    <Rule Id="CA1812" Action="None" /> <!-- internal class never instatiated -->
     <Rule Id="CA1814" Action="None" /> <!-- .ctor uses a multidimensional array. Replace it with a jagged array if possible. -->
     <Rule Id="CA1815" Action="None" /> <!-- KeyEvent should override method -->
     <Rule Id="CA1816" Action="None" />
+    <Rule Id="CA1819" Action="None" /> <!-- Properties should not return arrays -->
     <Rule Id="CA1820" Action="None" /> <!-- Test for empty strings not using Equality check -->
     <Rule Id="CA1823" Action="None" /> <!-- Unused field -->
     <Rule Id="CA1824" Action="None" /> <!-- Mark assemblies with NeutralResourcesLanguageAttribute -->
     <Rule Id="CA1825" Action="None" /> <!-- Avoid unnecessary zero-length array allocations -->
     <Rule Id="CA1827" Action="None" /> <!-- Count() is used where Any() could be used instead to improve performance -->
     <Rule Id="CA1829" Action="None" /> <!-- Use the "Count" property instead of Enumerable.Count() -->
+    <Rule Id="CA1716" Action="None" /> <!-- Rename virtual/interface member so it no longer conflicts with reserved language -->
     <Rule Id="CA1720" Action="None" /> <!-- Identifier contains type name -->
     <Rule Id="CA1031" Action="None" /> <!-- Catch more specific exception type -->
     <Rule Id="CA5369" Action="None" /> <!-- Overload is potentially unsafe -->
     <Rule Id="CA3075" Action="None" /> <!-- Unsafe overload of 'Deserialize' method -->
+    <Rule Id="CA5351" Action="None" /> <!-- Don't use MD5 -->
   </Rules>
 </RuleSet>

--- a/StyleCop.ruleset
+++ b/StyleCop.ruleset
@@ -85,20 +85,28 @@
     <Rule Id="CA2000" Action="None" /> <!-- Call on object before all references to it are out of scope -->
     <Rule Id="CA2002" Action="None" /> <!-- Do not lock on objects with weak identity -->
     <Rule Id="CA2007" Action="None" /> <!-- Call ConfigureAwait on the awaited task -->
+    <Rule Id="CA1040" Action="None" /> <!-- Avoid empty interfaces -->
+    <Rule Id="CA1060" Action="None" /> <!-- Move pinvokes to native methods class -->
     <Rule Id="CA1303" Action="None" /> <!-- Passing literal string as parameter -->
     <Rule Id="CA1822" Action="None" /> <!-- Member can be marked as static -->
+    <Rule Id="CA2101" Action="None" /> <!--  Specify marshaling for P/Invoke string arguments -->
     <Rule Id="CA2208" Action="None" /> <!-- Method passes parameter as the message argument -->
     <Rule Id="CA2211" Action="None" /> <!-- Non-constant fields should not be visible -->
     <Rule Id="CA2213" Action="None" /> <!-- Change Dispore method to call Close or Dispose -->
+    <Rule Id="CA2227" Action="None" /> <!-- Change to be read-only by removing the property setter -->
     <Rule Id="CA1724" Action="None" /> <!-- Naming conflict -->
     <Rule Id="CA1051" Action="None" /> <!-- Do not declare visible instance fields -->
     <Rule Id="CA1304" Action="None" /> <!-- string.ToUpper behavior could vary based on the current user's locale settings -->
     <Rule Id="CA1305" Action="None" /> <!-- String parsing behavior could vary based on the current user's locale settings -->
     <Rule Id="CA1307" Action="None" /> <!-- string.EndsWith behavior could vary based on the current user's locale settings -->
+    <Rule Id="CA1034" Action="None" /> <!-- Do not nest type -->
+    <Rule Id="CA1401" Action="None" />
     <Rule Id="CA1062" Action="None" /> <!-- Validate parameters for externally visible methods -->
     <Rule Id="CA1063" Action="None" />
     <Rule Id="CA1016" Action="None" /> <!-- Mark assemblies with assembly version -->
     <Rule Id="CA1707" Action="None" /> <!-- Remove underscore for member name -->
+    <Rule Id="CA1714" Action="None" /> <!-- Flags enums should have plural names -->
+    <Rule Id="CA1715" Action="None" /> <!-- Prefix generic type parameter name with 'T' -->
     <Rule Id="CA1801" Action="None" /> <!-- Parameter list of method is never used. Remove the parameter or use it in the method body -->
     <Rule Id="CA1802" Action="None" /> <!-- readonly field should be const -->
     <Rule Id="CA1806" Action="None" /> <!-- Using method without reference to error -->
@@ -115,66 +123,5 @@
     <Rule Id="CA1031" Action="None" /> <!-- Catch more specific exception type -->
     <Rule Id="CA5369" Action="None" /> <!-- Overload is potentially unsafe -->
     <Rule Id="CA3075" Action="None" /> <!-- Unsafe overload of 'Deserialize' method -->
-  </Rules>
-  <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
-    <Rule Id="CA1001" Action="Warning" />
-    <Rule Id="CA1009" Action="Warning" />
-    <Rule Id="CA1033" Action="Warning" />
-    <Rule Id="CA1049" Action="Warning" />
-    <Rule Id="CA1060" Action="Warning" />
-    <Rule Id="CA1061" Action="Warning" />
-    <Rule Id="CA1065" Action="Warning" />
-    <Rule Id="CA1301" Action="Warning" />
-    <Rule Id="CA1400" Action="Warning" />
-    <Rule Id="CA1401" Action="Warning" />
-    <Rule Id="CA1403" Action="Warning" />
-    <Rule Id="CA1404" Action="Warning" />
-    <Rule Id="CA1405" Action="Warning" />
-    <Rule Id="CA1410" Action="Warning" />
-    <Rule Id="CA1415" Action="Warning" />
-    <Rule Id="CA1821" Action="Warning" />
-    <Rule Id="CA1900" Action="Warning" />
-    <Rule Id="CA1901" Action="Warning" />
-    <Rule Id="CA2100" Action="Warning" />
-    <Rule Id="CA2101" Action="Warning" />
-    <Rule Id="CA2108" Action="Warning" />
-    <Rule Id="CA2111" Action="Warning" />
-    <Rule Id="CA2112" Action="Warning" />
-    <Rule Id="CA2114" Action="Warning" />
-    <Rule Id="CA2116" Action="Warning" />
-    <Rule Id="CA2117" Action="Warning" />
-    <Rule Id="CA2122" Action="Warning" />
-    <Rule Id="CA2123" Action="Warning" />
-    <Rule Id="CA2124" Action="Warning" />
-    <Rule Id="CA2126" Action="Warning" />
-    <Rule Id="CA2131" Action="Warning" />
-    <Rule Id="CA2132" Action="Warning" />
-    <Rule Id="CA2133" Action="Warning" />
-    <Rule Id="CA2134" Action="Warning" />
-    <Rule Id="CA2137" Action="Warning" />
-    <Rule Id="CA2138" Action="Warning" />
-    <Rule Id="CA2140" Action="Warning" />
-    <Rule Id="CA2141" Action="Warning" />
-    <Rule Id="CA2146" Action="Warning" />
-    <Rule Id="CA2147" Action="Warning" />
-    <Rule Id="CA2149" Action="Warning" />
-    <Rule Id="CA2200" Action="Warning" />
-    <Rule Id="CA2202" Action="Warning" />
-    <Rule Id="CA2207" Action="Warning" />
-    <Rule Id="CA2212" Action="Warning" />
-    <Rule Id="CA2214" Action="Warning" />
-    <Rule Id="CA2216" Action="Warning" />
-    <Rule Id="CA2220" Action="Warning" />
-    <Rule Id="CA2229" Action="Warning" />
-    <Rule Id="CA2231" Action="Warning" />
-    <Rule Id="CA2232" Action="Warning" />
-    <Rule Id="CA2235" Action="Warning" />
-    <Rule Id="CA2236" Action="Warning" />
-    <Rule Id="CA2237" Action="Warning" />
-    <Rule Id="CA2238" Action="Warning" />
-    <Rule Id="CA2240" Action="Warning" />
-    <Rule Id="CA2241" Action="Warning" />
-    <Rule Id="CA2242" Action="Warning" />
-    <Rule Id="CS0649" Action="None" /> <!-- Field is never assigned to -->
   </Rules>
 </RuleSet>

--- a/StyleCop.ruleset
+++ b/StyleCop.ruleset
@@ -83,6 +83,10 @@
   </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.FxCopAnalyzers" RuleNamespace="Microsoft.CodeAnalysis.FxCopAnalyzers">
     <Rule Id="CA2000" Action="None" /> <!-- Call on object before all references to it are out of scope -->
+    <Rule Id="CA1303" Action="None" /> <!-- Passing literal string as parameter -->
+    <Rule Id="CA1822" Action="None" /> <!-- Member can be marked as static -->
+    <Rule Id="CA2213" Action="None" /> <!-- Change Dispore method to call Close or Dispose -->
+    <Rule Id="CA1724" Action="None" /> <!-- Naming conflict -->
   </Rules>
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1001" Action="Warning" />
@@ -133,7 +137,6 @@
     <Rule Id="CA2202" Action="Warning" />
     <Rule Id="CA2207" Action="Warning" />
     <Rule Id="CA2212" Action="Warning" />
-    <Rule Id="CA2213" Action="Warning" />
     <Rule Id="CA2214" Action="Warning" />
     <Rule Id="CA2216" Action="Warning" />
     <Rule Id="CA2220" Action="Warning" />

--- a/StyleCop.ruleset
+++ b/StyleCop.ruleset
@@ -83,10 +83,19 @@
   </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.FxCopAnalyzers" RuleNamespace="Microsoft.CodeAnalysis.FxCopAnalyzers">
     <Rule Id="CA2000" Action="None" /> <!-- Call on object before all references to it are out of scope -->
+    <Rule Id="CA2007" Action="None" /> <!-- Call ConfigureAwait on the awaited task -->
     <Rule Id="CA1303" Action="None" /> <!-- Passing literal string as parameter -->
     <Rule Id="CA1822" Action="None" /> <!-- Member can be marked as static -->
     <Rule Id="CA2213" Action="None" /> <!-- Change Dispore method to call Close or Dispose -->
     <Rule Id="CA1724" Action="None" /> <!-- Naming conflict -->
+    <Rule Id="CA1051" Action="None" /> <!-- Do not declare visible instance fields -->
+    <Rule Id="CA1304" Action="None" /> <!-- string.ToUpper behavior could vary based on the current user's locale settings -->
+    <Rule Id="CA1305" Action="None" /> <!-- String parsing behavior could vary based on the current user's locale settings -->
+    <Rule Id="CA1062" Action="None" /> <!-- Validate parameters for externally visible methods -->
+    <Rule Id="CA1063" Action="None" />
+    <Rule Id="CA1816" Action="None" />
+    <Rule Id="CA1720" Action="None" /> <!-- Identifier contains type name -->
+    <Rule Id="CA1031" Action="None" /> <!-- Catch more specific exception type -->
   </Rules>
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1001" Action="Warning" />
@@ -96,7 +105,6 @@
     <Rule Id="CA1049" Action="Warning" />
     <Rule Id="CA1060" Action="Warning" />
     <Rule Id="CA1061" Action="Warning" />
-    <Rule Id="CA1063" Action="Warning" />
     <Rule Id="CA1065" Action="Warning" />
     <Rule Id="CA1301" Action="Warning" />
     <Rule Id="CA1400" Action="Warning" />

--- a/StyleCop.ruleset
+++ b/StyleCop.ruleset
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="StyleCop Rules" ToolsVersion="10.0">
+  <Localization ResourceAssembly="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.dll" ResourceBaseName="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.Localized">
+    <Name Resource="MinimumRecommendedRules_Name" />
+    <Description Resource="MinimumRecommendedRules_Description" />
+  </Localization>
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA1600" Action="None" /> <!-- Elements should be documented -->
+    <Rule Id="SA1633" Action="None" /> <!-- File should have header -->
+    <Rule Id="SA0001" Action="None" /> <!-- XML comments -->
+    <Rule Id="SA1101" Action="None" /> <!-- Prefix local calls with this -->
+    <Rule Id="SA1407" Action="None" /> <!-- Arithmetic expressions should declare precedence -->
+    <Rule Id="SA1116" Action="None" /> <!-- Split parameters should start on line after declaration -->
+    <Rule Id="SA1309" Action="None" /> <!-- Field names should not begin with underscore -->
+    <Rule Id="SA1402" Action="None" /> <!-- File may only contain a single type -->
+    <Rule Id="SA1204" Action="None" /> <!-- Static elements should appear before instance elements -->
+    <Rule Id="SA1604" Action="None" /> <!-- Element documentation should have summary -->
+    <Rule Id="SA1516" Action="None" /> <!-- Elements should be separated by blank line -->
+    <Rule Id="SA1649" Action="None" /> <!-- File name should match first type name -->
+    <Rule Id="SA1128" Action="None" /> <!-- Put constructor initializers on their own line -->
+    <Rule Id="SA1122" Action="None" /> <!-- Use string.Empty for empty strings -->
+    <Rule Id="SA1413" Action="None" /> <!-- Use trailing comma in multi-line initializers -->
+    <Rule Id="SA1117" Action="None" /> <!-- Parameters should be on same line or separate lines -->
+    <Rule Id="SA1602" Action="None" /> <!-- Enumeration items should be documented -->
+    <Rule Id="SA1108" Action="None" /> <!-- Block statements should not contain embedded comments -->
+    <Rule Id="SA1601" Action="None" /> <!-- Partial elements should be documented -->
+    <Rule Id="SA1401" Action="None" /> <!-- Fields should be private -->
+    <Rule Id="SA1404" Action="None" /> <!-- Code analysis suppression should have justification -->
+    <Rule Id="SA1515" Action="None" /> <!-- Single-line comment should be preceded by blank line -->
+    <Rule Id="SA1512" Action="None" /> <!-- Single-line comments should not be followed by blank line -->
+    <Rule Id="SA1118" Action="None" /> <!-- Parameter should not span multiple lines -->
+    <Rule Id="SA1127" Action="None" /> <!-- Generic type constraints should be on their own line -->
+    <Rule Id="SA1132" Action="None" /> <!-- Do not combine fields -->
+    <Rule Id="SA1501" Action="None" /> <!-- Statement should not be on a single line -->
+    <Rule Id="SA1502" Action="None" /> <!-- Element should not be on a single line -->
+    <Rule Id="SA1203" Action="None" /> <!-- Constants should appear before fields -->
+    <Rule Id="SA1214" Action="None" /> <!-- Readonly fields should appear before non-readonly fields -->
+    <Rule Id="SA1133" Action="None" /> <!-- Do not combine attributes -->
+    <Rule Id="SA1202" Action="None" /> <!-- Elements should be ordered by access -->
+    <Rule Id="SA1201" Action="None" /> <!-- Elements should appear in the correct order -->
+    <Rule Id="SA1005" Action="None" /> <!-- Single line comment should begin with a space -->
+    <Rule Id="SA1513" Action="None" /> <!-- Closing brace should be followed by blank line -->
+    <Rule Id="SA1507" Action="None" /> <!-- Code should not contain multiple blank lines in a row -->
+    <Rule Id="SA1009" Action="None" /> <!-- Closing parenthesis should not be preceded by a space -->
+    <Rule Id="SA1313" Action="None" /> <!-- Parameter should begin with lower-case letter -->
+    <Rule Id="SA1124" Action="None" /> <!-- Do not use regions -->
+    <Rule Id="SA1503" Action="None" /> <!-- Braces should not be omitted -->
+    <Rule Id="SA1119" Action="None" /> <!-- Statement should not use unnecessary parenthesis -->
+    <Rule Id="SA1136" Action="None" /> <!-- Enum values should be on separate lines -->
+    <Rule Id="SA1300" Action="None" /> <!-- Element should begin with an uppercase letter -->
+    <Rule Id="SA1111" Action="None" /> <!-- Closing parenthesis should be on line of last parameter -->
+    <Rule Id="SA1210" Action="None" /> <!-- Using directives should be ordered alphabetically by the namespaces -->
+    <Rule Id="SA1400" Action="None" /> <!-- Element should declare an access modifier -->
+    <Rule Id="SA1131" Action="None" /> <!-- Constant values should appear on the right-hand side of comparisons -->
+    <Rule Id="SA1520" Action="None" /> <!-- Use braces consistently -->
+    <Rule Id="SA1519" Action="None" /> <!-- Braces should not be omitted from multi-line child statement -->
+    <Rule Id="SA1025" Action="None" /> <!-- Code should not contain multiple whitespace characters in a row -->
+    <Rule Id="SA1001" Action="None" /> <!-- Commas should be followed by whitespace -->
+    <Rule Id="SA1306" Action="None" /> <!-- Field should begin with lower-case letter -->
+    <Rule Id="SA1614" Action="None" /> <!-- The documentation text within the param tag must not be empty -->
+    <Rule Id="SA1139" Action="None" /> <!-- Use literal suffix notation instead of casting -->
+    <Rule Id="SA1120" Action="None" /> <!-- Comments should contain text -->
+    <Rule Id="SA1307" Action="None" /> <!-- Field should begin with upper-case letter -->
+    <Rule Id="SA1113" Action="None" /> <!-- Comma should be on the same line as previous parameter -->
+    <Rule Id="SA1107" Action="None" /> <!-- Code should not contain multiple statements on one line -->
+    <Rule Id="SA1312" Action="None" /> <!-- Variable 'Handle' should begin with lower-case letter -->
+    <Rule Id="SA1121" Action="None" /> <!-- Use built-in type alias -->
+    <Rule Id="SA1405" Action="None" /> <!-- Debug.Assert should provide message text -->
+    <Rule Id="SA1100" Action="None" /> <!-- Do not prefix calls with base unless local implementation exists -->
+    <Rule Id="SA1310" Action="None" /> <!-- Field should not contain an underscore -->
+    <Rule Id="SA1303" Action="None" /> <!-- Const field names should begin with upper-case letter -->
+    <Rule Id="SA1500" Action="None" /> <!-- Braces for multi-line statements should not share line -->
+    <Rule Id="SA1314" Action="None" /> <!-- Type parameter names should begin with T -->
+    <Rule Id="SA1212" Action="None" /> <!-- A get accessor appears after a set accessor within a property or indexer -->
+    <Rule Id="SA1311" Action="None" /> <!-- Static readonly fields should begin with upper-case letter -->
+    <Rule Id="SA1408" Action="None" /> <!-- Conditional expressions should declare precedence -->
+    <Rule Id="SA1129" Action="None" /> <!-- Do not use default value type constructor -->
+    <Rule Id="SA1003" Action="None" /> <!-- Operator whitespace -->
+    <Rule Id="SA1411" Action="None" /> <!-- Attribute constructor should not use unnecessary parenthesis -->
+    <Rule Id="SA1134" Action="None" /> <!-- Each attribute should be placed on its own line of code -->
+    <Rule Id="SA1504" Action="None" /> <!-- All accessors should be single-line or multi-line -->
+    <Rule Id="SA1130" Action="None" /> <!-- Use lambda syntax -->
+  </Rules>
+  <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+    <Rule Id="CA1001" Action="Warning" />
+    <Rule Id="CA1009" Action="Warning" />
+    <Rule Id="CA1016" Action="Warning" />
+    <Rule Id="CA1033" Action="Warning" />
+    <Rule Id="CA1049" Action="Warning" />
+    <Rule Id="CA1060" Action="Warning" />
+    <Rule Id="CA1061" Action="Warning" />
+    <Rule Id="CA1063" Action="Warning" />
+    <Rule Id="CA1065" Action="Warning" />
+    <Rule Id="CA1301" Action="Warning" />
+    <Rule Id="CA1400" Action="Warning" />
+    <Rule Id="CA1401" Action="Warning" />
+    <Rule Id="CA1403" Action="Warning" />
+    <Rule Id="CA1404" Action="Warning" />
+    <Rule Id="CA1405" Action="Warning" />
+    <Rule Id="CA1410" Action="Warning" />
+    <Rule Id="CA1415" Action="Warning" />
+    <Rule Id="CA1821" Action="Warning" />
+    <Rule Id="CA1900" Action="Warning" />
+    <Rule Id="CA1901" Action="Warning" />
+    <Rule Id="CA2002" Action="Warning" />
+    <Rule Id="CA2100" Action="Warning" />
+    <Rule Id="CA2101" Action="Warning" />
+    <Rule Id="CA2108" Action="Warning" />
+    <Rule Id="CA2111" Action="Warning" />
+    <Rule Id="CA2112" Action="Warning" />
+    <Rule Id="CA2114" Action="Warning" />
+    <Rule Id="CA2116" Action="Warning" />
+    <Rule Id="CA2117" Action="Warning" />
+    <Rule Id="CA2122" Action="Warning" />
+    <Rule Id="CA2123" Action="Warning" />
+    <Rule Id="CA2124" Action="Warning" />
+    <Rule Id="CA2126" Action="Warning" />
+    <Rule Id="CA2131" Action="Warning" />
+    <Rule Id="CA2132" Action="Warning" />
+    <Rule Id="CA2133" Action="Warning" />
+    <Rule Id="CA2134" Action="Warning" />
+    <Rule Id="CA2137" Action="Warning" />
+    <Rule Id="CA2138" Action="Warning" />
+    <Rule Id="CA2140" Action="Warning" />
+    <Rule Id="CA2141" Action="Warning" />
+    <Rule Id="CA2146" Action="Warning" />
+    <Rule Id="CA2147" Action="Warning" />
+    <Rule Id="CA2149" Action="Warning" />
+    <Rule Id="CA2200" Action="Warning" />
+    <Rule Id="CA2202" Action="Warning" />
+    <Rule Id="CA2207" Action="Warning" />
+    <Rule Id="CA2212" Action="Warning" />
+    <Rule Id="CA2213" Action="Warning" />
+    <Rule Id="CA2214" Action="Warning" />
+    <Rule Id="CA2216" Action="Warning" />
+    <Rule Id="CA2220" Action="Warning" />
+    <Rule Id="CA2229" Action="Warning" />
+    <Rule Id="CA2231" Action="Warning" />
+    <Rule Id="CA2232" Action="Warning" />
+    <Rule Id="CA2235" Action="Warning" />
+    <Rule Id="CA2236" Action="Warning" />
+    <Rule Id="CA2237" Action="Warning" />
+    <Rule Id="CA2238" Action="Warning" />
+    <Rule Id="CA2240" Action="Warning" />
+    <Rule Id="CA2241" Action="Warning" />
+    <Rule Id="CA2242" Action="Warning" />
+    <Rule Id="CS0649" Action="None" /> <!-- Field is never assigned to -->
+  </Rules>
+</RuleSet>

--- a/StyleCop.ruleset
+++ b/StyleCop.ruleset
@@ -83,6 +83,7 @@
   </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.FxCopAnalyzers" RuleNamespace="Microsoft.CodeAnalysis.FxCopAnalyzers">
     <Rule Id="CA2000" Action="None" /> <!-- Call on object before all references to it are out of scope -->
+    <Rule Id="CA2002" Action="None" /> <!-- Do not lock on objects with weak identity -->
     <Rule Id="CA2007" Action="None" /> <!-- Call ConfigureAwait on the awaited task -->
     <Rule Id="CA1303" Action="None" /> <!-- Passing literal string as parameter -->
     <Rule Id="CA1822" Action="None" /> <!-- Member can be marked as static -->
@@ -91,16 +92,22 @@
     <Rule Id="CA1051" Action="None" /> <!-- Do not declare visible instance fields -->
     <Rule Id="CA1304" Action="None" /> <!-- string.ToUpper behavior could vary based on the current user's locale settings -->
     <Rule Id="CA1305" Action="None" /> <!-- String parsing behavior could vary based on the current user's locale settings -->
+    <Rule Id="CA1307" Action="None" /> <!-- string.EndsWith behavior could vary based on the current user's locale settings -->
     <Rule Id="CA1062" Action="None" /> <!-- Validate parameters for externally visible methods -->
     <Rule Id="CA1063" Action="None" />
+    <Rule Id="CA1016" Action="None" /> <!-- Mark assemblies with assembly version -->
+    <Rule Id="CA1707" Action="None" /> <!-- Remove underscore for member name -->
     <Rule Id="CA1816" Action="None" />
+    <Rule Id="CA1820" Action="None" /> <!-- Test for empty strings not using Equality check -->
+    <Rule Id="CA1824" Action="None" /> <!-- Mark assemblies with NeutralResourcesLanguageAttribute -->
+    <Rule Id="CA1825" Action="None" /> <!-- Avoid unnecessary zero-length array allocations -->
+    <Rule Id="CA1829" Action="None" /> <!-- Use the "Count" property instead of Enumerable.Count() -->
     <Rule Id="CA1720" Action="None" /> <!-- Identifier contains type name -->
     <Rule Id="CA1031" Action="None" /> <!-- Catch more specific exception type -->
   </Rules>
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1001" Action="Warning" />
     <Rule Id="CA1009" Action="Warning" />
-    <Rule Id="CA1016" Action="Warning" />
     <Rule Id="CA1033" Action="Warning" />
     <Rule Id="CA1049" Action="Warning" />
     <Rule Id="CA1060" Action="Warning" />
@@ -117,7 +124,6 @@
     <Rule Id="CA1821" Action="Warning" />
     <Rule Id="CA1900" Action="Warning" />
     <Rule Id="CA1901" Action="Warning" />
-    <Rule Id="CA2002" Action="Warning" />
     <Rule Id="CA2100" Action="Warning" />
     <Rule Id="CA2101" Action="Warning" />
     <Rule Id="CA2108" Action="Warning" />

--- a/StyleCop.ruleset
+++ b/StyleCop.ruleset
@@ -81,6 +81,9 @@
     <Rule Id="SA1504" Action="None" /> <!-- All accessors should be single-line or multi-line -->
     <Rule Id="SA1130" Action="None" /> <!-- Use lambda syntax -->
   </Rules>
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.FxCopAnalyzers" RuleNamespace="Microsoft.CodeAnalysis.FxCopAnalyzers">
+    <Rule Id="CA2000" Action="None" /> <!-- Call on object before all references to it are out of scope -->
+  </Rules>
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1001" Action="Warning" />
     <Rule Id="CA1009" Action="Warning" />

--- a/StyleCop.ruleset
+++ b/StyleCop.ruleset
@@ -87,6 +87,8 @@
     <Rule Id="CA2007" Action="None" /> <!-- Call ConfigureAwait on the awaited task -->
     <Rule Id="CA1303" Action="None" /> <!-- Passing literal string as parameter -->
     <Rule Id="CA1822" Action="None" /> <!-- Member can be marked as static -->
+    <Rule Id="CA2208" Action="None" /> <!-- Method passes parameter as the message argument -->
+    <Rule Id="CA2211" Action="None" /> <!-- Non-constant fields should not be visible -->
     <Rule Id="CA2213" Action="None" /> <!-- Change Dispore method to call Close or Dispose -->
     <Rule Id="CA1724" Action="None" /> <!-- Naming conflict -->
     <Rule Id="CA1051" Action="None" /> <!-- Do not declare visible instance fields -->
@@ -97,13 +99,22 @@
     <Rule Id="CA1063" Action="None" />
     <Rule Id="CA1016" Action="None" /> <!-- Mark assemblies with assembly version -->
     <Rule Id="CA1707" Action="None" /> <!-- Remove underscore for member name -->
+    <Rule Id="CA1801" Action="None" /> <!-- Parameter list of method is never used. Remove the parameter or use it in the method body -->
+    <Rule Id="CA1802" Action="None" /> <!-- readonly field should be const -->
+    <Rule Id="CA1806" Action="None" /> <!-- Using method without reference to error -->
+    <Rule Id="CA1814" Action="None" /> <!-- .ctor uses a multidimensional array. Replace it with a jagged array if possible. -->
+    <Rule Id="CA1815" Action="None" /> <!-- KeyEvent should override method -->
     <Rule Id="CA1816" Action="None" />
     <Rule Id="CA1820" Action="None" /> <!-- Test for empty strings not using Equality check -->
+    <Rule Id="CA1823" Action="None" /> <!-- Unused field -->
     <Rule Id="CA1824" Action="None" /> <!-- Mark assemblies with NeutralResourcesLanguageAttribute -->
     <Rule Id="CA1825" Action="None" /> <!-- Avoid unnecessary zero-length array allocations -->
+    <Rule Id="CA1827" Action="None" /> <!-- Count() is used where Any() could be used instead to improve performance -->
     <Rule Id="CA1829" Action="None" /> <!-- Use the "Count" property instead of Enumerable.Count() -->
     <Rule Id="CA1720" Action="None" /> <!-- Identifier contains type name -->
     <Rule Id="CA1031" Action="None" /> <!-- Catch more specific exception type -->
+    <Rule Id="CA5369" Action="None" /> <!-- Overload is potentially unsafe -->
+    <Rule Id="CA3075" Action="None" /> <!-- Unsafe overload of 'Deserialize' method -->
   </Rules>
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1001" Action="Warning" />


### PR DESCRIPTION
Major changes:

1. README has been updated to include some fancy styling and badges. Here, my goal was to match the trends of active popular open-source repositories.
1. Integrate StyleCop into the repository. For the most part, I disabled all of the rules that would have a significant impact on the style of the code. I made two exceptions to this:
    1.  I updated `using` directives to be inside of a namespace. See [SA1200](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1200.md)
    1. I removed many, many tab characters from the code and replaced them with a set of four spaces each
1. Integrated FxCop, which is more about syntax and correctness than about style.

I made some other minor changes. The most noteworthy:

- Some `.csproj` file updates to remove build warnings on my end. Please look over these modifications as I have very little insight into the broader impact of my changes.
- I updated the license file to extend the copyright year.
- CI integration will now run on pushes *and* pull requests
- Many trailing whitespace were removed