### PR TITLE
Build Bizhawk and CemuStub in RTCV 505 branch

### DIFF
--- a/.github/workflows/buildConsumers.yml
+++ b/.github/workflows/buildConsumers.yml
@@ -1,0 +1,52 @@
+name: Build consumers
+on:
+  push:
+    branches:
+      - '505'
+  pull_request:
+    branches:
+      - '505'
+
+jobs:
+  buildAll:
+    runs-on: windows-2019
+    steps:
+    # Checkout relevant code
+    - name: Checkout current build target
+      uses: actions/checkout@v2
+      with:
+        path: 'RTCV'
+    - name: Checkout consumer - Bizhawk
+      uses: actions/checkout@v2
+      with:
+        repository: 'ircluzar/Bizhawk-Vanguard'
+        ref: 'master'
+        path: 'Bizhawk-Vanguard'
+    - name: Checkout consumer - CemuStub
+      uses: actions/checkout@v2
+      with:
+        repository: 'ircluzar/CemuStub-Vanguard'
+        ref: 'master'
+        path: 'CemuStub-Vanguard'
+
+    # Setup Tooling
+    - name: Setup Nuget
+      uses: nuget/setup-nuget@v1.0.2
+      with:
+        nuget-version: 'latest'
+    - name: Setup MSBuild.exe
+      uses: microsoft/setup-msbuild@v1.0.0
+
+    # Restore nuget packages for all targets
+    - name: Restore Nuget packages in current build target
+      run: nuget restore '.\RTCV\'
+    - name: Restore Nuget packages in consumer - Bizhawk
+      run: nuget restore '.\Bizhawk-Vanguard\Real-Time Corruptor\BizHawk_RTC\BizHawk.sln'
+    - name: Restore Nuget packages in consumer - CemuStub
+      run: nuget restore '.\CemuStub-Vanguard\'
+
+    # Build consumers
+    - name: Build consumer - Bizhawk with MSBuild
+      run: msbuild '.\Bizhawk-Vanguard\Real-Time Corruptor\BizHawk_RTC\BizHawk.sln'
+    - name: Build consumer - CemuStub with MSBuild
+      run: msbuild '.\CemuStub-Vanguard\'

--- a/.github/workflows/buildConsumers.yml
+++ b/.github/workflows/buildConsumers.yml
@@ -1,11 +1,11 @@
-name: Build consumers
+name: Build Bizhawk and CemuStub
 on:
   push:
     branches:
-      - '505'
+      - '505' # Bizhawk and CemuStub depend on RTCV 505
   pull_request:
     branches:
-      - '505'
+      - '505' # Bizhawk and CemuStub depend on RTCV 505
 
 jobs:
   buildAll:
@@ -45,8 +45,8 @@ jobs:
     - name: Restore Nuget packages in consumer - CemuStub
       run: nuget restore '.\CemuStub-Vanguard\'
 
-    # Build consumers
-    - name: Build consumer - Bizhawk with MSBuild
+    # Build consumers  of RTCV
+    - name: Build Bizhawk-Vanguard
       run: msbuild '.\Bizhawk-Vanguard\Real-Time Corruptor\BizHawk_RTC\BizHawk.sln'
-    - name: Build consumer - CemuStub with MSBuild
+    - name: Build CemuStub-Vanguard
       run: msbuild '.\CemuStub-Vanguard\'


### PR DESCRIPTION
My goal with this change is to avoid having check-ins to RTCV break Bizhawk-Vanguard or CemuStub-Vanguard.

To accomplish this, PRs and pushes to the `505` branch will checkout and build Bizhawk-Vanguard and CemuStub-Vanguard on their master branches.

This change will potentially break RTCV's CI if:
- Breaking changes are checked-in to RTCV that don't have corresponding fixes in Bizhawk/CemuStub
- Breaking changes are checked-in to Bizhawk/CemuStub that don't have a corresponding fix in RTCV.

This change may not be the best way to accomplish my goal, but it may be an improvement over nothing.

[Passing build example here](https://github.com/scowalt/RTCV/runs/770728516?check_suite_focus=true)