### PR TITLE
Fixing FxCop and StyleCop rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -285,9 +285,6 @@ dotnet_diagnostic.CA1712.severity = none
 # Flags enums should have plural names
 dotnet_diagnostic.CA1714.severity = none
 
-# Prefix generic type parameter name with 'T'
-dotnet_diagnostic.CA1715.severity = none
-
 # Rename virtual/interface member so it no longer conflicts with reserved language
 dotnet_diagnostic.CA1716.severity = none
 
@@ -328,6 +325,7 @@ dotnet_diagnostic.CA1819.severity = none
 dotnet_diagnostic.CA1820.severity = none
 
 # Member can be marked as static
+# NOTE: Fixing this requires a simultaneous fix in Bizhawk-Vanguard
 dotnet_diagnostic.CA1822.severity = none
 
 # Mark assemblies with NeutralResourcesLanguageAttribute

--- a/.editorconfig
+++ b/.editorconfig
@@ -433,9 +433,6 @@ dotnet_diagnostic.SA1118.severity = none
 # Statement should not use unnecessary parenthesis
 dotnet_diagnostic.SA1119.severity = none
 
-# Comments should contain text
-dotnet_diagnostic.SA1120.severity = none
-
 # Use built-in type alias
 dotnet_diagnostic.SA1121.severity = none
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -394,9 +394,6 @@ dotnet_diagnostic.SA0001.severity = none
 # Commas should be followed by whitespace
 dotnet_diagnostic.SA1001.severity = none
 
-# Operator whitespace
-dotnet_diagnostic.SA1003.severity = none
-
 # Single line comment should begin with a space
 dotnet_diagnostic.SA1005.severity = none
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -330,9 +330,6 @@ dotnet_diagnostic.CA1820.severity = none
 # Member can be marked as static
 dotnet_diagnostic.CA1822.severity = none
 
-# Unused field
-dotnet_diagnostic.CA1823.severity = none
-
 # Mark assemblies with NeutralResourcesLanguageAttribute
 dotnet_diagnostic.CA1824.severity = none
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -457,9 +457,6 @@ dotnet_diagnostic.SA1130.severity = none
 # Constant values should appear on the right-hand side of comparisons
 dotnet_diagnostic.SA1131.severity = none
 
-# Do not combine fields
-dotnet_diagnostic.SA1132.severity = none
-
 # Do not combine attributes
 dotnet_diagnostic.SA1133.severity = none
 

--- a/Source/Frontend/UI/Components/Blast Editor/RTC_SanitizeTool_Form.cs
+++ b/Source/Frontend/UI/Components/Blast Editor/RTC_SanitizeTool_Form.cs
@@ -177,7 +177,7 @@ namespace RTCV.UI
             BlastLayer changes = (BlastLayer)S.GET<RTC_NewBlastEditor_Form>().currentSK.BlastLayer.Clone();
             BlastLayer modified = (BlastLayer)originalBlastLayer.Clone();
 
-            foreach (var unit in changes.Layer.Where(it=> it.IsEnabled))
+            foreach (var unit in changes.Layer.Where(it => it.IsEnabled))
             {
                 var TargetUnit = modified.Layer.FirstOrDefault(it =>
                 it.Address == unit.Address &&
@@ -266,7 +266,7 @@ namespace RTCV.UI
 
             int original_remainder = originalSize;
             int original_maxsteps = 0;
-            while (original_remainder>1)
+            while (original_remainder > 1)
             {
                 original_remainder = original_remainder / 2;
                 original_maxsteps++;

--- a/Source/Frontend/UI/Components/Glitch Harvester/RTC_SavestateManager_Form.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/RTC_SavestateManager_Form.cs
@@ -20,7 +20,6 @@ namespace RTCV.UI
         public new void HandleMouseDown(object s, MouseEventArgs e) => base.HandleMouseDown(s, e);
         public new void HandleFormClosing(object s, FormClosingEventArgs e) => base.HandleFormClosing(s, e);
 
-        private Dictionary<string, TextBox> StateBoxes = new Dictionary<string, TextBox>();
         private BindingSource savestateBindingSource = new BindingSource(new BindingList<SaveStateKey>(), null);
 
         private bool LoadSavestateOnClick = false;

--- a/Source/Frontend/UI/Forms/RTC_AnalyticsTool_Form.cs
+++ b/Source/Frontend/UI/Forms/RTC_AnalyticsTool_Form.cs
@@ -249,7 +249,7 @@
         {
             int activity = 0;
 
-            for (int i=0; i<stripe.Count; i++)
+            for (int i = 0; i < stripe.Count; i++)
             {
                 if (i == 0)
                     continue;
@@ -259,7 +259,7 @@
                 byte[] prevWord = stripe[i - 1];
                 byte[] currentWord = stripe[i];
 
-                for (int j=0; j< currentWord.Length; j++)
+                for (int j = 0; j < currentWord.Length; j++)
                 {
                     if (prevWord[j] != currentWord[j])
                     {
@@ -314,7 +314,7 @@
         {
             byte[] output = new byte[wordSize];
 
-            for (int i=0; i < wordSize; i++)
+            for (int i = 0; i < wordSize; i++)
                 output[i] = dump[index + i];
 
             return output;

--- a/Source/Frontend/UI/Input/Bindings.cs
+++ b/Source/Frontend/UI/Input/Bindings.cs
@@ -8,8 +8,6 @@ namespace RTCV.UI.Input
     public static class Bindings
     {
         private static readonly WorkingDictionary<string, List<string>> _bindings = new WorkingDictionary<string, List<string>>();
-        private static readonly WorkingDictionary<string, bool> _buttons = new WorkingDictionary<string, bool>();
-        private static readonly WorkingDictionary<string, int> _buttonStarts = new WorkingDictionary<string, int>();
 
         // Looks for bindings which are activated by the supplied physical button.
         public static List<string> SearchBindings(string button)

--- a/Source/Frontend/UI/Input/Input.cs
+++ b/Source/Frontend/UI/Input/Input.cs
@@ -36,19 +36,19 @@
             // Summary:
             //     The bitmask to extract modifiers from a key value.
             Modifiers = -65536,
-            //
+
             // Summary:
             //     No key pressed.
             None = 0,
-            //
+
             // Summary:
             //     The SHIFT modifier key.
             Shift = 65536,
-            //
+
             // Summary:
             //     The CTRL modifier key.
             Control = 131072,
-            //
+
             // Summary:
             //     The ALT modifier key.
             Alt = 262144,

--- a/Source/Frontend/UI/UIConnector.cs
+++ b/Source/Frontend/UI/UIConnector.cs
@@ -11,7 +11,6 @@ namespace RTCV.UI
     {
         private NetCoreReceiver receiver;
         public NetCoreConnector netConn;
-        private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 
         public UIConnector(NetCoreReceiver _receiver)
         {

--- a/Source/Frontend/UI/UICore.cs
+++ b/Source/Frontend/UI/UICore.cs
@@ -904,7 +904,7 @@ namespace RTCV.UI
             //x.Substring(x.LastIndexOf('\\')+1)[0] != '$'
             //checks if first char is $
 
-            string[] paths = System.IO.Directory.GetFiles(dir).Where(x => x.EndsWith(".txt", StringComparison.OrdinalIgnoreCase) && x.Substring(x.LastIndexOf('\\')+1)[0] != '$').ToArray();
+            string[] paths = System.IO.Directory.GetFiles(dir).Where(x => x.EndsWith(".txt", StringComparison.OrdinalIgnoreCase) && x.Substring(x.LastIndexOf('\\') + 1)[0] != '$').ToArray();
             paths = paths.OrderBy(x => x).ToArray();
 
             List<string> hashes = Filtering.LoadListsFromPaths(paths);

--- a/Source/Frontend/UI/UI_Extensions.cs
+++ b/Source/Frontend/UI/UI_Extensions.cs
@@ -2639,18 +2639,18 @@ public class SortableBindingList<T> : BindingList<T> where T : class
 /// <summary>
 /// A dictionary that creates new values on the fly as necessary so that any key you need will be defined.
 /// </summary>
-/// <typeparam name="K">dictionary keys</typeparam>
-/// <typeparam name="V">dictionary values</typeparam>
+/// <typeparam name="TKey">dictionary keys</typeparam>
+/// <typeparam name="TValue">dictionary values</typeparam>
 [Serializable]
-public class WorkingDictionary<K, V> : Dictionary<K, V> where V : new()
+public class WorkingDictionary<TKey, TValue> : Dictionary<TKey, TValue> where TValue : new()
 {
-    public new V this[K key]
+    public new TValue this[TKey key]
     {
         get
         {
-            if (!TryGetValue(key, out V temp))
+            if (!TryGetValue(key, out TValue temp))
             {
-                temp = this[key] = new V();
+                temp = this[key] = new TValue();
             }
 
             return temp;

--- a/Source/Libraries/Common/StaticTools.cs
+++ b/Source/Libraries/Common/StaticTools.cs
@@ -258,7 +258,6 @@ namespace RTCV.Common
         internal const int MF_GRAYED = 0x1;             //disabled button status (enabled = false)
         internal const int MF_DISABLED = 0x00000002;    //disabled button status
 
-        private const uint StdOutputHandle = 0xFFFFFFF5;
 
         [DllImport("kernel32.dll")]
         private static extern IntPtr GetStdHandle(uint nStdHandle);

--- a/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
+++ b/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
@@ -502,7 +502,8 @@ namespace RTCV.CorruptCore
                         {
                             void a()
                             {
-                                MemoryDomains.GenerateActiveTableDump((string)(advancedMessage.objectValue as object[])[0],
+                                MemoryDomains.GenerateActiveTableDump(
+                                    (string)(advancedMessage.objectValue as object[])[0],
                                     (string)(advancedMessage.objectValue as object[])[1]);
                             }
 

--- a/Source/Libraries/CorruptCore/CorruptCore_Extensions.cs
+++ b/Source/Libraries/CorruptCore/CorruptCore_Extensions.cs
@@ -1294,7 +1294,8 @@ namespace RTCV.CorruptCore
             return path + " " + remainder;
         }
 
-        private static IntPtr oldOut, conOut;
+        private static IntPtr oldOut;
+        private static IntPtr conOut;
         private static bool hasConsole;
         private static bool attachedConsole;
         private static bool shouldRedirectStdout;

--- a/Source/Libraries/CorruptCore/CorruptCore_Extensions.cs
+++ b/Source/Libraries/CorruptCore/CorruptCore_Extensions.cs
@@ -703,7 +703,7 @@ namespace RTCV.CorruptCore
 
             var newArray = new byte[bytes.Length];
 
-            for (int i=0; i<bytes.Length; i++)
+            for (int i = 0; i < bytes.Length; i++)
             {
                 if (bytes[i] == null)
                     newArray[i] = 69;

--- a/Source/Libraries/CorruptCore/Diff.cs
+++ b/Source/Libraries/CorruptCore/Diff.cs
@@ -99,7 +99,8 @@
         /// </summary>
         private struct SMSRD
         {
-            internal int x, y;
+            internal int x;
+            internal int y;
             // internal int u, v;  // 2002.09.20: no need for 2 points
         }
 

--- a/Source/Libraries/CorruptCore/Filtering.cs
+++ b/Source/Libraries/CorruptCore/Filtering.cs
@@ -277,7 +277,7 @@
             {
                 bool found = true;
 
-                for (int i = 0; i<item.Length; i++)
+                for (int i = 0; i < item.Length; i++)
                 {
                     if (item[i] == null) //ignoring wildcards (null values)
                         continue;

--- a/Source/Libraries/CorruptCore/Objects.cs
+++ b/Source/Libraries/CorruptCore/Objects.cs
@@ -1592,7 +1592,7 @@ namespace RTCV.CorruptCore
                 {
                     if (BigEndian)
                     {
-                        bu.Value[i] = Value[end - (i +1)];
+                        bu.Value[i] = Value[end - (i + 1)];
                     }
                     else
                     {

--- a/Source/Libraries/CorruptCore/StepActions.cs
+++ b/Source/Libraries/CorruptCore/StepActions.cs
@@ -16,7 +16,6 @@ namespace RTCV.CorruptCore
     ///appliedLifetime and appliedInfinite are the two collections where we store what we want to actually be applied
     public static class StepActions
     {
-        private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
         private static List<List<BlastUnit>> buListCollection = new List<List<BlastUnit>>();
 
         private static LinkedList<List<BlastUnit>> queued = new LinkedList<List<BlastUnit>>();

--- a/Source/Libraries/NetCore/NetCore_Extensions.cs
+++ b/Source/Libraries/NetCore/NetCore_Extensions.cs
@@ -103,8 +103,6 @@ namespace RTCV.NetCore
             internal const int MF_GRAYED = 0x1;             //disabled button status (enabled = false)
             internal const int MF_DISABLED = 0x00000002;    //disabled button status
 
-            private const uint StdOutputHandle = 0xFFFFFFF5;
-
             [DllImport("kernel32.dll")]
             private static extern IntPtr GetStdHandle(uint nStdHandle);
 


### PR DESCRIPTION
Fixed the following rules:
- CA1823 - Unused field
- CA1715 - Prefix generic type parameter name with 'T'
- SA1003 - Operator whitespace
- SA1120 - Comments should contain text
- SA1132 - Do not combine fields