### PR TITLE
Fixed CA1016

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -220,9 +220,6 @@ csharp_preserve_single_line_statements = true
 # Class owns disposable fields but is not disposable
 dotnet_diagnostic.CA1001.severity = none
 
-# Mark assemblies with assembly version
-dotnet_diagnostic.CA1016.severity = none
-
 # If possible, make the underlying type of FileType System.Int32 instead of uint
 dotnet_diagnostic.CA1028.severity = none
 

--- a/Source/Plugins/HexEditor/HexEditor.csproj
+++ b/Source/Plugins/HexEditor/HexEditor.csproj
@@ -86,6 +86,7 @@
     </Compile>
     <Compile Include="Loader.cs" />
     <Compile Include="VanguardConnector.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="HexEditor.resx">


### PR DESCRIPTION
`HexEditor` plugin never included its `AssemblyInfo.cs`, which was causing missing version information.