### PR TITLE
Fixed CA1040 - Avoid empty interfaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -235,9 +235,6 @@ dotnet_diagnostic.CA1032.severity = none
 # Do not nest type
 dotnet_diagnostic.CA1034.severity = none
 
-# Avoid empty interfaces
-dotnet_diagnostic.CA1040.severity = none
-
 # Do not declare visible instance fields
 dotnet_diagnostic.CA1051.severity = none
 

--- a/Source/Frontend/UI/UI_Extensions.cs
+++ b/Source/Frontend/UI/UI_Extensions.cs
@@ -155,10 +155,6 @@ namespace RTCV.UI
             T NewMe();
         }
 
-        public interface IColorable
-        {
-        }
-
         public class RTC_Standalone_Form : Form { }
 
         public class ComponentForm : Form

--- a/Source/Libraries/Common/StaticTools.cs
+++ b/Source/Libraries/Common/StaticTools.cs
@@ -13,6 +13,7 @@ namespace RTCV.Common
     using System.Windows.Forms;
     using NLog;
 
+    #pragma warning disable CA1040 // Allow this interface to be empty, since it's used to signal auto-coloriation for a class
     // Implementing this interface causes auto-coloration.
     public interface IAutoColorize { }
 


### PR DESCRIPTION
`IColorable` is dead code.

`IAutoColorize` is used in many places in the code. I added this empty interface as an exception.