### PR TITLE
Treat warnings as errors in CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -242,7 +242,7 @@ dotnet_diagnostic.CA1040.severity = none
 dotnet_diagnostic.CA1051.severity = none
 
 # Type is a static holder type but is neither static nor NotInheritable
-# dotnet_diagnostic.CA1052.severity = none
+dotnet_diagnostic.CA1052.severity = none
 
 # Move pinvokes to native methods class
 dotnet_diagnostic.CA1060.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -242,7 +242,7 @@ dotnet_diagnostic.CA1040.severity = none
 dotnet_diagnostic.CA1051.severity = none
 
 # Type is a static holder type but is neither static nor NotInheritable
-dotnet_diagnostic.CA1052.severity = none
+# dotnet_diagnostic.CA1052.severity = none
 
 # Move pinvokes to native methods class
 dotnet_diagnostic.CA1060.severity = none

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,4 +15,4 @@ jobs:
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.0
     - name: Build with MSBuild
-      run: msbuild RTCV.sln
+      run: msbuild RTCV.sln /p:TreatWarningsAsErrors=true


### PR DESCRIPTION
Enable `TreatWarningsAsErrors` for builds of `RTCV`. This will help prevent regressions for all of the rules we're enabling.

I wish there was an option for a Github Action to fail with a warning. However, a job can currently only pass or fail. As it stands now, if a job passes, it may still have rule violations that emit as warnings.

[Example of a job with a warning failing.](https://github.com/scowalt/RTCV/actions/runs/138521322)