### PR TITLE
Fixed CA1065 and CA1066

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -253,12 +253,6 @@ dotnet_diagnostic.CA1062.severity = none
 # Modify 'Dispose' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns.
 dotnet_diagnostic.CA1063.severity = none
 
-# Method creates exception
-dotnet_diagnostic.CA1065.severity = none
-
-# Implement IEquatable when overriding Object.Equals
-dotnet_diagnostic.CA1066.severity = none
-
 # Passing literal string as parameter
 dotnet_diagnostic.CA1303.severity = none
 

--- a/Source/Frontend/UI/Input/Input.cs
+++ b/Source/Frontend/UI/Input/Input.cs
@@ -98,7 +98,7 @@
             Press, Release
         }
 
-        public struct LogicalButton : IEquatable<object>
+        public struct LogicalButton : IEquatable<LogicalButton>
         {
             public LogicalButton(string button, ModifierKey modifiers)
             {
@@ -126,6 +126,11 @@
             public override bool Equals(object obj)
             {
                 var other = (LogicalButton)obj;
+                return Equals(other);
+            }
+
+            public bool Equals(LogicalButton other)
+            {
                 return other == this;
             }
 

--- a/Source/Frontend/UI/Input/Input.cs
+++ b/Source/Frontend/UI/Input/Input.cs
@@ -98,7 +98,7 @@
             Press, Release
         }
 
-        public struct LogicalButton
+        public struct LogicalButton : IEquatable<object>
         {
             public LogicalButton(string button, ModifierKey modifiers)
             {

--- a/Source/Libraries/CorruptCore/MemoryDomains.cs
+++ b/Source/Libraries/CorruptCore/MemoryDomains.cs
@@ -1846,6 +1846,7 @@ namespace RTCV.CorruptCore
             //return lastMemoryDump;
         }
 
+        #pragma warning disable CA1065
         public override byte[][] lastMemoryDump
         {
             get => throw new Exception("FORBIDDEN USE OF LASTMEMORYDUMP ON MULTIPLEFILEINTERFACE");


### PR DESCRIPTION
For `CA1065`, I'm not touching the only current violation, but I think it's worthwhile to prevent further violations.

For `CA1066`, I fixed the only violation, implementing the `IEquatable` interface.