### PR TITLE
Fixed CA3075 and CA5369 - Unsafe Deserialize

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -376,14 +376,8 @@ dotnet_diagnostic.CA2234.severity = none
 # Add [Serializable] to class
 dotnet_diagnostic.CA2237.severity = none
 
-# Unsafe overload of 'Deserialize' method
-dotnet_diagnostic.CA3075.severity = none
-
 # Don't use MD5
 dotnet_diagnostic.CA5351.severity = none
-
-# Overload is potentially unsafe
-dotnet_diagnostic.CA5369.severity = none
 
 # Field never assigned to
 dotnet_diagnostic.CS0649.severity = none

--- a/Source/Frontend/UI/Components/Memory Tools/RTC_VmdAct_Form.cs
+++ b/Source/Frontend/UI/Components/Memory Tools/RTC_VmdAct_Form.cs
@@ -7,6 +7,7 @@
     using System.IO;
     using System.Linq;
     using System.Windows.Forms;
+    using System.Xml;
     using System.Xml.Serialization;
     using RTCV.CorruptCore;
     using RTCV.NetCore;
@@ -340,7 +341,7 @@
                 using (FileStream FS = File.Open(currentFilename, FileMode.OpenOrCreate))
                 {
                     XmlSerializer xs = new XmlSerializer(typeof(ActiveTableObject));
-                    ActiveTableObject act = (ActiveTableObject)xs.Deserialize(FS);
+                    ActiveTableObject act = (ActiveTableObject)xs.Deserialize(XmlReader.Create(FS));
                     FS.Close();
                     SetActiveTable(act);
                     ActLoadedFromFile = true;
@@ -388,7 +389,7 @@
             using (FileStream FS = File.Open(tempFilename, FileMode.OpenOrCreate))
             {
                 XmlSerializer xs = new XmlSerializer(typeof(ActiveTableObject));
-                act = (ActiveTableObject)xs.Deserialize(FS);
+                act = (ActiveTableObject)xs.Deserialize(XmlReader.Create(FS));
                 FS.Close();
             }
             long[] subtractiveActiveTable = act.Data;
@@ -434,7 +435,7 @@
                 using (FileStream FS = File.Open(tempFilename, FileMode.OpenOrCreate))
                 {
                     XmlSerializer xs = new XmlSerializer(typeof(ActiveTableObject));
-                    act = (ActiveTableObject)xs.Deserialize(FS);
+                    act = (ActiveTableObject)xs.Deserialize(XmlReader.Create(FS));
                     FS.Close();
                 }
                 long[] additiveActiveTable = act.Data;


### PR DESCRIPTION
[This article](https://docs.microsoft.com/en-us/visualstudio/code-quality/ca5369?view=vs-2019) has a pretty concise breakdown of the motivation behind this fix.

I doubt this has any functional impact on the code, but I also haven't tested it. If you give me a scenario that hits `RTC_VmdAct_Form::btnActiveTableAddFile_Click` I can run it locally to make sure there are no functional issues.