### PR TITLE
Fixed CA1824 (for real this time) - NeutralResourcesLanguage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -305,9 +305,6 @@ dotnet_diagnostic.CA1820.severity = none
 # NOTE: Fixing this requires a simultaneous fix in Bizhawk-Vanguard
 dotnet_diagnostic.CA1822.severity = none
 
-# Mark assemblies with NeutralResourcesLanguageAttribute
-dotnet_diagnostic.CA1824.severity = none
-
 # Avoid unnecessary zero-length array allocations
 dotnet_diagnostic.CA1825.severity = none
 

--- a/Source/Frontend/StandaloneRTC/Properties/AssemblyInfo.cs
+++ b/Source/Frontend/StandaloneRTC/Properties/AssemblyInfo.cs
@@ -13,6 +13,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
+[assembly: System.Resources.NeutralResourcesLanguage("en")]
+
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.

--- a/Source/Frontend/UI/Properties/AssemblyInfo.cs
+++ b/Source/Frontend/UI/Properties/AssemblyInfo.cs
@@ -13,6 +13,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
+[assembly: System.Resources.NeutralResourcesLanguage("en")]
+
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.


### PR DESCRIPTION
`NeutralResourcesLanguage` attributes were required to be added to a couple of the projects.

I missed these warnings in my initial fix because VSCode swallows project-level warnings (warnings that don't originate from source code).