### PR TITLE
Refactor duplicate `GenerateBlastLayer` code

### DIFF
--- a/Source/Libraries/CorruptCore/CorruptCore.cs
+++ b/Source/Libraries/CorruptCore/CorruptCore.cs
@@ -671,6 +671,53 @@ namespace RTCV.CorruptCore
             }
         }
 
+        public static BlastLayer GenerateBlastLayerOnAllThreads()
+        {
+            //We pull the domains here because if the syncsettings changed, there's a chance the domains changed
+            var domains = (string[])AllSpec.UISpec["SELECTEDDOMAINS"];
+            var cpus = Environment.ProcessorCount;
+
+            //If there is only one thread, only generate a single BlastLayer.
+            if (cpus == 1 || AllSpec.VanguardSpec[VSPEC.SUPPORTS_MULTITHREAD] == null)
+            {
+                return GenerateBlastLayer(domains);
+            }
+
+            //if emulator supports multithreaded access of the domains, disregard the emulation thread and just span threads...
+            var reminder = Intensity % (cpus - 1);
+            var splitintensity = (Intensity - reminder) / (cpus - 1);
+            var tasks = new Task<BlastLayer>[cpus];
+            for (var i = 0; i < cpus; i++)
+            {
+                var requestedIntensity = splitintensity;
+                if (i == 0 && reminder != 0)
+                {
+                    requestedIntensity = reminder;
+                }
+
+                tasks[i] = Task.Factory.StartNew(() => GenerateBlastLayer(domains, requestedIntensity));
+            }
+
+            Task.WaitAll(tasks);
+
+            BlastLayer bl = tasks[0].Result ?? new BlastLayer();
+
+            for (var i = 1; i < tasks.Length; i++)
+            {
+                if (tasks[i].Result != null)
+                {
+                    bl.Layer.AddRange(tasks[i].Result.Layer);
+                }
+            }
+
+            if (bl.Layer.Count == 0)
+            {
+                bl = null;
+            }
+
+            return bl;
+        }
+
         //Generates or applies a blast layer using one of the multiple BlastRadius algorithms
 
         public static BlastLayer GenerateBlastLayer(string[] selectedDomains, long overrideIntensity = -1)
@@ -968,55 +1015,7 @@ namespace RTCV.CorruptCore
             BlastLayer bl = null;
             void _generateAndBlast()
             {
-                //We pull the domains here because if the syncsettings changed, there's a chance the domains changed
-                string[] domains = (string[])AllSpec.UISpec["SELECTEDDOMAINS"];
-
-                var cpus = Environment.ProcessorCount;
-
-                if (cpus == 1 || AllSpec.VanguardSpec[VSPEC.SUPPORTS_MULTITHREAD] == null)
-                {
-                    bl = RtcCore.GenerateBlastLayer(domains);
-                }
-                else
-                {
-                    //if emulator supports multithreaded access of the domains, disregard the emulation thread and just span threads...
-                    long reminder = RtcCore.Intensity % (cpus - 1);
-                    long splitintensity = (RtcCore.Intensity - reminder) / (cpus - 1);
-
-                    Task<BlastLayer>[] tasks = new Task<BlastLayer>[cpus];
-                    for (int i = 0; i < cpus; i++)
-                    {
-                        long requestedIntensity = splitintensity;
-
-                        if (i == 0 && reminder != 0)
-                        {
-                            requestedIntensity = reminder;
-                        }
-
-                        tasks[i] = Task.Factory.StartNew(() => RtcCore.GenerateBlastLayer(domains, requestedIntensity));
-                    }
-
-                    Task.WaitAll(tasks);
-
-                    bl = tasks[0].Result ?? new BlastLayer();
-
-                    if (tasks.Length > 1)
-                    {
-                        for (int i = 1; i < tasks.Length; i++)
-                        {
-                            if (tasks[i].Result != null)
-                            {
-                                bl.Layer.AddRange(tasks[i].Result.Layer);
-                            }
-                        }
-                    }
-
-                    if (bl.Layer.Count == 0)
-                    {
-                        bl = null;
-                    }
-                }
-
+                bl = GenerateBlastLayerOnAllThreads();
                 bl?.Apply(false, true);
             }
             //If the emulator uses callbacks, we do everything on the main thread and once we're done, we unpause emulation

--- a/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
+++ b/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
@@ -215,60 +215,7 @@ namespace RTCV.CorruptCore
                                         StockpileManager_EmuSide.LoadState_NET(sk, false);
                                     }
 
-                                    //We pull the domains here because if the syncsettings changed, there's a chance the domains changed
-                                    string[] domains = (string[])AllSpec.UISpec["SELECTEDDOMAINS"];
-
-                                    var cpus = Environment.ProcessorCount;
-
-                                    if (cpus == 1 || AllSpec.VanguardSpec[VSPEC.SUPPORTS_MULTITHREAD] == null)
-                                    {
-                                        bl = RtcCore.GenerateBlastLayer(domains);
-                                    }
-                                    else
-                                    {
-                                        //if emulator supports multithreaded access of the domains, disregard the emulation thread and just span threads...
-
-                                        long reminder = RtcCore.Intensity % (cpus - 1);
-
-                                        long splitintensity = (RtcCore.Intensity - reminder) / (cpus - 1);
-
-                                        Task<BlastLayer>[] tasks = new Task<BlastLayer>[cpus];
-                                        for (int i = 0; i < cpus; i++)
-                                        {
-                                            long requestedIntensity = splitintensity;
-
-                                            if (i == 0 && reminder != 0)
-                                            {
-                                                requestedIntensity = reminder;
-                                            }
-
-                                            tasks[i] = Task.Factory.StartNew(() =>
-                                                RtcCore.GenerateBlastLayer(domains, requestedIntensity));
-                                        }
-
-                                        Task.WaitAll(tasks);
-
-                                        bl = tasks[0]
-                                            .Result ?? new BlastLayer();
-
-                                        if (tasks.Length > 1)
-                                        {
-                                            for (int i = 1; i < tasks.Length; i++)
-                                            {
-                                                if (tasks[i]
-                                                    .Result != null)
-                                                {
-                                                    bl.Layer.AddRange(tasks[i]
-                                                        .Result.Layer);
-                                                }
-                                            }
-                                        }
-
-                                        if (bl.Layer.Count == 0)
-                                        {
-                                            bl = null;
-                                        }
-                                    }
+                                    bl = RtcCore.GenerateBlastLayerOnAllThreads();
 
                                     if (applyBlastLayer)
                                     {


### PR DESCRIPTION
A couple of spots in code handle generating multiple `BlastLayer`s based on the number of threads. This change refactors those two spots to use the same help function. I cleaned up the code in this help function a bit to match our `.editorconfig` standards.