### PR TITLE
Remove duplicate code in VMD generation

### DIFF
--- a/Source/Frontend/UI/Components/Memory Tools/RTC_VmdGen_Form.cs
+++ b/Source/Frontend/UI/Components/Memory Tools/RTC_VmdGen_Form.cs
@@ -59,26 +59,6 @@
             currentDomainSize = Convert.ToInt64(mi.Size);
         }
 
-        public long SafeStringToLong(string input)
-        {
-            try
-            {
-                if (input.IndexOf("0X", StringComparison.OrdinalIgnoreCase) >= 0)
-                {
-                    return long.Parse(input.Substring(2), NumberStyles.HexNumber);
-                }
-                else
-                {
-                    return long.Parse(input, NumberStyles.HexNumber);
-                }
-            }
-            catch (FormatException e)
-            {
-                Console.Write(e);
-                return -1;
-            }
-        }
-
         public void btnGenerateVMD_Click(object sender, EventArgs e)
         {
             GenerateVMD();
@@ -145,48 +125,7 @@
                     trimmedLine = trimmedLine.Substring(1);
                 }
 
-                string[] lineParts = trimmedLine.Split('-');
-
-                if (lineParts.Length > 1)
-                {
-                    long start = SafeStringToLong(lineParts[0]);
-                    long end = SafeStringToLong(lineParts[1]);
-
-                    if (end < start)
-                    {
-                        continue;
-                    }
-
-                    if (end >= currentDomainSize)
-                    {
-                        end = Convert.ToInt64(currentDomainSize - 1);
-                    }
-
-                    if (remove)
-                    {
-                        proto.RemoveRanges.Add(new long[] { start, end });
-                    }
-                    else
-                    {
-                        proto.AddRanges.Add(new long[] { start, end });
-                    }
-                }
-                else
-                {
-                    long address = SafeStringToLong(lineParts[0]);
-
-                    if (address > 0 && address < currentDomainSize)
-                    {
-                        if (remove)
-                        {
-                            proto.RemoveSingles.Add(address);
-                        }
-                        else
-                        {
-                            proto.AddSingles.Add(address);
-                        }
-                    }
-                }
+                proto.AddFromTrimmedLine(trimmedLine, currentDomainSize, remove);
             }
 
             if (proto.AddRanges.Count == 0 && proto.AddSingles.Count == 0)

--- a/Source/Frontend/UI/Components/Memory Tools/RTC_VmdSimpleGen_Form.cs
+++ b/Source/Frontend/UI/Components/Memory Tools/RTC_VmdSimpleGen_Form.cs
@@ -84,26 +84,6 @@
             btnGenerateVMD.Enabled = true;
         }
 
-        public long SafeStringToLong(string input)
-        {
-            try
-            {
-                if (input.IndexOf("0X", StringComparison.OrdinalIgnoreCase) >= 0)
-                {
-                    return long.Parse(input.Substring(2), NumberStyles.HexNumber);
-                }
-                else
-                {
-                    return long.Parse(input, NumberStyles.HexNumber);
-                }
-            }
-            catch (FormatException e)
-            {
-                Console.Write(e);
-                return -1;
-            }
-        }
-
         private void btnGenerateVMD_Click(object sender, EventArgs e)
         {
             GenerateVMD();
@@ -172,48 +152,7 @@
                     trimmedLine = trimmedLine.Substring(1);
                 }
 
-                string[] lineParts = trimmedLine.Split('-');
-
-                if (lineParts.Length > 1)
-                {
-                    long start = SafeStringToLong(lineParts[0]);
-                    long end = SafeStringToLong(lineParts[1]);
-
-                    if (end < start)
-                    {
-                        continue;
-                    }
-
-                    if (end >= currentDomainSize)
-                    {
-                        end = Convert.ToInt64(currentDomainSize - 1);
-                    }
-
-                    if (remove)
-                    {
-                        proto.RemoveRanges.Add(new long[] { start, end });
-                    }
-                    else
-                    {
-                        proto.AddRanges.Add(new long[] { start, end });
-                    }
-                }
-                else
-                {
-                    long address = SafeStringToLong(lineParts[0]);
-
-                    if (address > 0 && address < currentDomainSize)
-                    {
-                        if (remove)
-                        {
-                            proto.RemoveSingles.Add(address);
-                        }
-                        else
-                        {
-                            proto.AddSingles.Add(address);
-                        }
-                    }
-                }
+                proto.AddFromTrimmedLine(trimmedLine, currentDomainSize, remove);
             }
 
             if (proto.AddRanges.Count == 0 && proto.AddSingles.Count == 0)

--- a/Source/Libraries/CorruptCore/MemoryDomains.cs
+++ b/Source/Libraries/CorruptCore/MemoryDomains.cs
@@ -2,6 +2,7 @@ namespace RTCV.CorruptCore
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.IO;
     using System.IO.Compression;
     using System.Linq;
@@ -600,6 +601,72 @@ namespace RTCV.CorruptCore
             }
 
             return false;
+        }
+
+        public void AddFromTrimmedLine(string trimmedLine, long currentDomainSize, bool remove)
+        {
+            var lineParts = trimmedLine.Split('-');
+
+            if (lineParts.Length > 1)
+            {
+                var start = SafeStringToLong(lineParts[0]);
+                var end = SafeStringToLong(lineParts[1]);
+
+                if (end < start)
+                {
+                    return;
+                }
+
+                if (end >= currentDomainSize)
+                {
+                    end = Convert.ToInt64(currentDomainSize - 1);
+                }
+
+                if (remove)
+                {
+                    RemoveRanges.Add(new long[] { start, end });
+                }
+                else
+                {
+                    AddRanges.Add(new long[] { start, end });
+                }
+            }
+            else
+            {
+                var address = SafeStringToLong(lineParts[0]);
+
+                if (address > 0 && address < currentDomainSize)
+                {
+                    if (remove)
+                    {
+                        RemoveSingles.Add(address);
+                    }
+                    else
+                    {
+                        AddSingles.Add(address);
+                    }
+                }
+            }
+        }
+
+        private static long SafeStringToLong(string input)
+        {
+            try
+            {
+                if (input.IndexOf("0X", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return long.Parse(input.Substring(2), NumberStyles.HexNumber);
+                }
+                else
+                {
+                    return long.Parse(input, NumberStyles.HexNumber);
+                }
+            }
+            catch (FormatException e)
+            {
+                Console.Write(e);
+                return -1;
+            }
         }
     }
 


### PR DESCRIPTION
Multiple different VMD generation forms had identical logic to parse a line and add it to a `VmdPrototype`. I refactored this out into one single function.