### PR TITLE
[Refactor] Merge duplicate file copy code in Memory Tools

### DIFF
--- a/Source/Frontend/UI/Components/Memory Tools/Common.cs
+++ b/Source/Frontend/UI/Components/Memory Tools/Common.cs
@@ -5,16 +5,23 @@ namespace RTCV.UI
 
     internal static class Common
     {
-        internal static bool CopyFileWithOverwritePrompt(string sourcePath, string targetDirectory)
+        internal static bool CopyFile(string sourcePath, string targetDirectory, bool confirmOverwrite)
         {
             var shortPath = sourcePath.Substring(sourcePath.LastIndexOf('\\') + 1);
             var targetPath = Path.Combine(targetDirectory, shortPath);
+            return ReplaceFile(sourcePath, targetPath, confirmOverwrite);
+        }
 
+        internal static bool ReplaceFile(string sourcePath, string targetPath, bool confirmOverwrite = false)
+        {
             if (File.Exists(targetPath))
             {
-                var result = MessageBox.Show("This file already exist in your VMDs folder, do you want to overwrite it?", "Overwrite file?", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
-                if (result == DialogResult.No)
-                    return true;
+                if (confirmOverwrite)
+                {
+                    var result = MessageBox.Show("This file already exist in your VMDs folder, do you want to overwrite it?", "Overwrite file?", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+                    if (result == DialogResult.No)
+                        return true;
+                }
 
                 File.Delete(targetPath);
             }

--- a/Source/Frontend/UI/Components/Memory Tools/Common.cs
+++ b/Source/Frontend/UI/Components/Memory Tools/Common.cs
@@ -1,0 +1,27 @@
+namespace RTCV.UI
+{
+    using System.IO;
+    using System.Windows.Forms;
+
+    internal static class Common
+    {
+        internal static bool CopyFileWithOverwritePrompt(string sourcePath, string targetDirectory)
+        {
+            var shortPath = sourcePath.Substring(sourcePath.LastIndexOf('\\') + 1);
+            var targetPath = Path.Combine(targetDirectory, shortPath);
+
+            if (File.Exists(targetPath))
+            {
+                var result = MessageBox.Show("This file already exist in your VMDs folder, do you want to overwrite it?", "Overwrite file?", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+                if (result == DialogResult.No)
+                    return true;
+
+                File.Delete(targetPath);
+            }
+
+            File.Copy(sourcePath, targetPath);
+
+            return false;
+        }
+    }
+}

--- a/Source/Frontend/UI/Components/Memory Tools/Common.cs
+++ b/Source/Frontend/UI/Components/Memory Tools/Common.cs
@@ -1,18 +1,20 @@
 namespace RTCV.UI
 {
+    using System;
     using System.IO;
     using System.Windows.Forms;
+    using System.Runtime.Serialization;
 
     internal static class Common
     {
-        internal static bool CopyFile(string sourcePath, string targetDirectory, bool confirmOverwrite)
+        internal static void CopyFile(string sourcePath, string targetDirectory, bool confirmOverwrite)
         {
             var shortPath = sourcePath.Substring(sourcePath.LastIndexOf('\\') + 1);
             var targetPath = Path.Combine(targetDirectory, shortPath);
-            return ReplaceFile(sourcePath, targetPath, confirmOverwrite);
+            ReplaceFile(sourcePath, targetPath, confirmOverwrite);
         }
 
-        internal static bool ReplaceFile(string sourcePath, string targetPath, bool confirmOverwrite = false)
+        internal static void ReplaceFile(string sourcePath, string targetPath, bool confirmOverwrite = false)
         {
             if (File.Exists(targetPath))
             {
@@ -20,15 +22,33 @@ namespace RTCV.UI
                 {
                     var result = MessageBox.Show("This file already exist in your VMDs folder, do you want to overwrite it?", "Overwrite file?", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
                     if (result == DialogResult.No)
-                        return true;
+                        throw new OverwriteCancelledException();
                 }
 
                 File.Delete(targetPath);
             }
 
             File.Copy(sourcePath, targetPath);
+        }
 
-            return false;
+        [Serializable]
+        public class OverwriteCancelledException : Exception
+        {
+            public OverwriteCancelledException() : base("File overwrite operation cancelled by user")
+            {
+            }
+
+            public OverwriteCancelledException(string message) : base(message)
+            {
+            }
+
+            public OverwriteCancelledException(string message, Exception innerException) : base(message, innerException)
+            {
+            }
+
+            protected OverwriteCancelledException(SerializationInfo info, StreamingContext context) : base(info, context)
+            {
+            }
         }
     }
 }

--- a/Source/Frontend/UI/Components/Memory Tools/RTC_MyLists.cs
+++ b/Source/Frontend/UI/Components/Memory Tools/RTC_MyLists.cs
@@ -2,6 +2,7 @@ namespace RTCV.UI
 {
     using System;
     using System.Data;
+    using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using System.Windows.Forms;
@@ -171,18 +172,14 @@ namespace RTCV.UI
 
             if (saveFileDialog1.ShowDialog() == DialogResult.OK)
             {
-                string filename = saveFileDialog1.FileName;
-
-                if (File.Exists(filename))
-                    File.Delete(filename);
-
-                File.Copy(path, filename);
+                var filename = saveFileDialog1.FileName;
+                Debug.Assert(!Common.ReplaceFile(path, filename));
             }
         }
 
         private void ImportList(string filename)
         {
-            var operationCancelled = Common.CopyFileWithOverwritePrompt(filename, RtcCore.listsDir);
+            var operationCancelled = Common.CopyFile(filename, RtcCore.listsDir, true);
             if (!operationCancelled)
             {
                 RefreshLists();

--- a/Source/Frontend/UI/Components/Memory Tools/RTC_MyLists.cs
+++ b/Source/Frontend/UI/Components/Memory Tools/RTC_MyLists.cs
@@ -34,7 +34,7 @@ namespace RTCV.UI
             {
                 if (f.Contains(".txt"))
                 {
-                    importList(f);
+                    ImportList(f);
                 }
             }
             RefreshLists();
@@ -180,25 +180,14 @@ namespace RTCV.UI
             }
         }
 
-        private void importList(string path)
+        private void ImportList(string filename)
         {
-            string shortPath = path.Substring(path.LastIndexOf('\\') + 1);
-            string targetPath = Path.Combine(RtcCore.listsDir, shortPath);
-
-            if (File.Exists(targetPath))
+            var operationCancelled = Common.CopyFileWithOverwritePrompt(filename, RtcCore.listsDir);
+            if (!operationCancelled)
             {
-                var result = MessageBox.Show("This file already exist in your VMDs folder, do you want to overwrite it?", "Overwrite file?", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
-                if (result == DialogResult.No)
-                    return;
-
-                File.Delete(targetPath);
+                RefreshLists();
             }
-
-            File.Copy(path, targetPath);
-
-            RefreshLists();
         }
-
 
         private void btnLoadVmd_Click(object sender, EventArgs e)
         {
@@ -282,7 +271,7 @@ namespace RTCV.UI
                 {
                     try
                     {
-                        importList(filename);
+                        ImportList(filename);
                     }
                     catch (Exception ex)
                     {

--- a/Source/Frontend/UI/Components/Memory Tools/RTC_MyLists.cs
+++ b/Source/Frontend/UI/Components/Memory Tools/RTC_MyLists.cs
@@ -2,7 +2,6 @@ namespace RTCV.UI
 {
     using System;
     using System.Data;
-    using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using System.Windows.Forms;

--- a/Source/Frontend/UI/Components/Memory Tools/RTC_MyLists.cs
+++ b/Source/Frontend/UI/Components/Memory Tools/RTC_MyLists.cs
@@ -173,16 +173,19 @@ namespace RTCV.UI
             if (saveFileDialog1.ShowDialog() == DialogResult.OK)
             {
                 var filename = saveFileDialog1.FileName;
-                Debug.Assert(!Common.ReplaceFile(path, filename));
+                Common.ReplaceFile(path, filename);
             }
         }
 
         private void ImportList(string filename)
         {
-            var operationCancelled = Common.CopyFile(filename, RtcCore.listsDir, true);
-            if (!operationCancelled)
+            try
             {
+                Common.CopyFile(filename, RtcCore.listsDir, true);
                 RefreshLists();
+            }
+            catch (Common.OverwriteCancelledException)
+            {
             }
         }
 

--- a/Source/Frontend/UI/Components/Memory Tools/RTC_MyVMDs_Form.cs
+++ b/Source/Frontend/UI/Components/Memory Tools/RTC_MyVMDs_Form.cs
@@ -32,7 +32,7 @@ namespace RTCV.UI
             {
                 if (f.Contains(".vmd"))
                 {
-                    importVmd(f);
+                    ImportVMD(f);
                 }
             }
             RefreshVMDs();
@@ -161,24 +161,13 @@ namespace RTCV.UI
             }
         }
 
-        private void importVmd(string path)
+        private void ImportVMD(string filename)
         {
-            string shortPath = path.Substring(path.LastIndexOf('\\') + 1);
-            string targetPath = Path.Combine(RtcCore.vmdsDir, shortPath);
-
-            if (File.Exists(targetPath))
+            var operationCancelled = Common.CopyFileWithOverwritePrompt(filename, RtcCore.vmdsDir);
+            if (!operationCancelled)
             {
-                var result = MessageBox.Show("This file already exist in your VMDs folder, do you want to overwrite it?", "Overwrite file?", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
-                if (result == DialogResult.No)
-                    return;
-
-                File.Delete(targetPath);
+                RefreshVMDs();
             }
-
-            File.Copy(path, targetPath);
-
-
-            RefreshVMDs();
         }
 
 
@@ -240,7 +229,7 @@ namespace RTCV.UI
                 {
                     try
                     {
-                        importVmd(filename);
+                        ImportVMD(filename);
                     }
                     catch (Exception ex)
                     {

--- a/Source/Frontend/UI/Components/Memory Tools/RTC_MyVMDs_Form.cs
+++ b/Source/Frontend/UI/Components/Memory Tools/RTC_MyVMDs_Form.cs
@@ -153,16 +153,19 @@ namespace RTCV.UI
             if (saveFileDialog1.ShowDialog() == DialogResult.OK)
             {
                 var filename = saveFileDialog1.FileName;
-                Debug.Assert(!Common.ReplaceFile(path, filename));
+                Common.ReplaceFile(path, filename);
             }
         }
 
         private void ImportVMD(string filename)
         {
-            var operationCancelled = Common.CopyFile(filename, RtcCore.vmdsDir, true);
-            if (!operationCancelled)
+            try
             {
+                Common.CopyFile(filename, RtcCore.vmdsDir, true);
                 RefreshVMDs();
+            }
+            catch (Common.OverwriteCancelledException)
+            {
             }
         }
 

--- a/Source/Frontend/UI/Components/Memory Tools/RTC_MyVMDs_Form.cs
+++ b/Source/Frontend/UI/Components/Memory Tools/RTC_MyVMDs_Form.cs
@@ -1,7 +1,6 @@
 namespace RTCV.UI
 {
     using System;
-    using System.Diagnostics;
     using System.IO;
     using System.Windows.Forms;
     using RTCV.CorruptCore;

--- a/Source/Frontend/UI/Components/Memory Tools/RTC_MyVMDs_Form.cs
+++ b/Source/Frontend/UI/Components/Memory Tools/RTC_MyVMDs_Form.cs
@@ -1,6 +1,7 @@
 namespace RTCV.UI
 {
     using System;
+    using System.Diagnostics;
     using System.IO;
     using System.Windows.Forms;
     using RTCV.CorruptCore;
@@ -151,19 +152,14 @@ namespace RTCV.UI
 
             if (saveFileDialog1.ShowDialog() == DialogResult.OK)
             {
-                string filename = saveFileDialog1.FileName;
-
-
-                if (File.Exists(filename))
-                    File.Delete(filename);
-
-                File.Copy(path, filename);
+                var filename = saveFileDialog1.FileName;
+                Debug.Assert(!Common.ReplaceFile(path, filename));
             }
         }
 
         private void ImportVMD(string filename)
         {
-            var operationCancelled = Common.CopyFileWithOverwritePrompt(filename, RtcCore.vmdsDir);
+            var operationCancelled = Common.CopyFile(filename, RtcCore.vmdsDir, true);
             if (!operationCancelled)
             {
                 RefreshVMDs();

--- a/Source/Frontend/UI/UI.csproj
+++ b/Source/Frontend/UI/UI.csproj
@@ -198,6 +198,7 @@
     <Compile Include="Components\Glitch Harvester\RTC_StockpileManager_Form.designer.cs">
       <DependentUpon>RTC_StockpileManager_Form.cs</DependentUpon>
     </Compile>
+    <Compile Include="Components\Memory Tools\Common.cs" />
     <Compile Include="Components\Memory Tools\RTC_DomainAnalytics_Form.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
Both `RTC_MyVMDs_Form` and `RTC_MyLists_Form` have identical code to copy a file with a blocking overwrite confirmation dialog. This change refactors that to call into a shared helper function.