### PR TITLE
[Bugfix] Fix crash on launch for Standalone RTC

### DIFF
--- a/Source/Frontend/UI/Components/Memory Tools/RTC_VmdAct_Form.cs
+++ b/Source/Frontend/UI/Components/Memory Tools/RTC_VmdAct_Form.cs
@@ -15,21 +15,6 @@
     using RTCV.Common.CustomExtensions;
     using static RTCV.UI.UI_Extensions;
 
-    [Serializable]
-    public class ActiveTableObject
-    {
-        public long[] Data { get; set; }
-
-        public ActiveTableObject()
-        {
-        }
-
-        public ActiveTableObject(long[] data)
-        {
-            Data = data;
-        }
-    }
-
     #pragma warning disable CA2213 //Component designer classes generate their own Dispose method
     public partial class RTC_VmdAct_Form : ComponentForm, IAutoColorize, IBlockable
     {

--- a/Source/Libraries/CorruptCore/ActivationTableObject.cs
+++ b/Source/Libraries/CorruptCore/ActivationTableObject.cs
@@ -1,0 +1,19 @@
+namespace RTCV.CorruptCore
+{
+    using System;
+
+    [Serializable]
+    public class ActiveTableObject
+    {
+        public long[] Data { get; set; }
+
+        public ActiveTableObject()
+        {
+        }
+
+        public ActiveTableObject(long[] data)
+        {
+            Data = data;
+        }
+    }
+}

--- a/Source/Libraries/CorruptCore/CorruptCore.csproj
+++ b/Source/Libraries/CorruptCore/CorruptCore.csproj
@@ -69,6 +69,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ActivationTableObject.cs" />
     <Compile Include="BitlogicListFilter.cs" />
     <Compile Include="Blast Generator Engines\RTC_ValueGenerator.cs" />
     <Compile Include="Blast Generator Engines\RTC_StoreGenerator.cs" />


### PR DESCRIPTION
In #53, I ended up breaking `RTC_VmdAct_Form` by changing the scope and namespace of `ActiveTableObject`.

I'm not entirely sure why that happened, but this is a quick fix.

I've validated locally that the Standalone RTC will launch with this change.