### PR TITLE
[Cleanup] Remove unused parameters from functions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -276,9 +276,6 @@ dotnet_diagnostic.CA1720.severity = none
 # Naming conflict
 dotnet_diagnostic.CA1724.severity = none
 
-# Parameter list of method is never used. Remove the parameter or use it in the method body
-dotnet_diagnostic.CA1801.severity = none
-
 # Using method without reference to error
 dotnet_diagnostic.CA1806.severity = none
 

--- a/Source/Frontend/UI/AutoKillSwitch.cs
+++ b/Source/Frontend/UI/AutoKillSwitch.cs
@@ -45,7 +45,7 @@ namespace RTCV.UI
 
         public static SoundPlayer[] LoadedSounds = null;
 
-        public static void PlayCrashSound(bool forcePlay = false)
+        public static void PlayCrashSound()
         {
             if (LoadedSounds?.Length != 0)
             {
@@ -112,7 +112,7 @@ namespace RTCV.UI
                         killswitchSpamPreventTimer.Tick += KillswitchSpamPreventTimer_Tick;
                         killswitchSpamPreventTimer.Start();
 
-                        PlayCrashSound(true);
+                        PlayCrashSound();
 
                         if (CorruptCore.RtcCore.EmuDir == null)
                         {

--- a/Source/Frontend/UI/Components/Blast Editor/RTC_SanitizeTool_Form.cs
+++ b/Source/Frontend/UI/Components/Blast Editor/RTC_SanitizeTool_Form.cs
@@ -223,7 +223,8 @@ namespace RTCV.UI
                 lastItem = lbSteps.Items[lbSteps.Items.Count - 2];
             }
 
-            T Cast<T>(object obj, T type) { return (T)obj; }
+            #pragma warning disable CA1801,IDE0060 //type is used for templating
+            static T Cast<T>(object obj, T type) { return (T)obj; }
             var modified = Cast(lastItem, new { Text = "", Value = new BlastLayer() });
 
             BlastLayer bl = (BlastLayer)modified.Value.Clone();

--- a/Source/Frontend/UI/Components/Glitch Harvester/RTC_StockpileManager_Form.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/RTC_StockpileManager_Form.cs
@@ -329,7 +329,7 @@ namespace RTCV.UI
             RemoveSelected();
         }
 
-        public void RemoveSelected(bool force = false)
+        public void RemoveSelected()
         {
             if (Control.ModifierKeys == Keys.Control || (dgvStockpile.SelectedRows.Count != 0 && (MessageBox.Show("Are you sure you want to remove the selected stockpile entries?", "Delete Stockpile Entry?", MessageBoxButtons.YesNo) == DialogResult.Yes)))
             {

--- a/Source/Frontend/UI/Forms/RTC_AnalyticsTool_Form.cs
+++ b/Source/Frontend/UI/Forms/RTC_AnalyticsTool_Form.cs
@@ -236,7 +236,7 @@
 
             return output;
         }
-        internal static int CrunchAlgoList(List<byte[]> stripe, string list)
+        internal static int CrunchAlgoList(/*List<byte[]> stripe, string list*/)
         {
             return 0;
         }

--- a/Source/Frontend/UI/Input/Gamepad.cs
+++ b/Source/Frontend/UI/Input/Gamepad.cs
@@ -245,7 +245,7 @@ namespace RTCV.UI.Input
         }
 
         // Note that this does not appear to work at this time. I probably need to have more infos.
-        public void SetVibration(int left, int right)
+        public void SetVibration(/*int left, int right*/)
         {
             int[] temp1, temp2;
             // my first clue that it doesnt work is that LEFT  and RIGHT _ARENT USED_

--- a/Source/Frontend/UI/Modular/UI_CanvasForm.cs
+++ b/Source/Frontend/UI/Modular/UI_CanvasForm.cs
@@ -114,7 +114,7 @@
             return outForm;
         }
 
-        public void ResizeCanvas(UI_CanvasForm targetForm, CanvasGrid canvasGrid)
+        public void ResizeCanvas(CanvasGrid canvasGrid)
         {
             this.SetSize(getTilePos(canvasGrid.x), getTilePos(canvasGrid.y));
         }
@@ -133,7 +133,7 @@
 
         public static void loadTileForm(UI_CanvasForm targetForm, CanvasGrid canvasGrid)
         {
-            targetForm.ResizeCanvas(targetForm, canvasGrid);
+            targetForm.ResizeCanvas(canvasGrid);
 
             for (int x = 0; x < canvasGrid.x; x++)
             {

--- a/Source/Libraries/Common/Controls/LogConsole.cs
+++ b/Source/Libraries/Common/Controls/LogConsole.cs
@@ -86,7 +86,9 @@ namespace RTCV.Common.Forms
             config.AddRule(LogLevel.Trace, LogLevel.Fatal, t);
             _logger = new LogFactory(config).GetCurrentClassLogger();
         }
-        public void InitializeCustomLogger(Layout layout, string fileName = null)
+
+        #pragma warning disable CA1801,IDE0060 //maxLines is unused but should be left in for external plugins
+        public void InitializeCustomLogger(int maxLines, Layout layout, string fileName = null)
         {
             if (layout == null)
                 layout = "${level} ${logger} ${message} ${onexception:|${newline}EXCEPTION OCCURRED\\:${exception:format=type,message,method:maxInnerExceptionLevel=5:innerFormat=shortType,message,method}${newline}";
@@ -110,10 +112,10 @@ namespace RTCV.Common.Forms
         {
             InitializeComponent();
         }
-        public LogConsole(Layout customLayout, string fileName = null)
+        public LogConsole(int maxLines, Layout customLayout, string fileName = null)
         {
             InitializeComponent();
-            InitializeCustomLogger(customLayout, fileName);
+            InitializeCustomLogger(maxLines, customLayout, fileName);
         }
     }
 }

--- a/Source/Libraries/Common/Controls/LogConsole.cs
+++ b/Source/Libraries/Common/Controls/LogConsole.cs
@@ -86,7 +86,7 @@ namespace RTCV.Common.Forms
             config.AddRule(LogLevel.Trace, LogLevel.Fatal, t);
             _logger = new LogFactory(config).GetCurrentClassLogger();
         }
-        public void InitializeCustomLogger(int maxLines, Layout layout, string fileName = null)
+        public void InitializeCustomLogger(Layout layout, string fileName = null)
         {
             if (layout == null)
                 layout = "${level} ${logger} ${message} ${onexception:|${newline}EXCEPTION OCCURRED\\:${exception:format=type,message,method:maxInnerExceptionLevel=5:innerFormat=shortType,message,method}${newline}";
@@ -110,10 +110,10 @@ namespace RTCV.Common.Forms
         {
             InitializeComponent();
         }
-        public LogConsole(int maxLines, Layout customLayout, string fileName = null)
+        public LogConsole(Layout customLayout, string fileName = null)
         {
             InitializeComponent();
-            InitializeCustomLogger(maxLines, customLayout, fileName);
+            InitializeCustomLogger(customLayout, fileName);
         }
     }
 }

--- a/Source/Libraries/Common/Forms/LogConsoleForm.cs
+++ b/Source/Libraries/Common/Forms/LogConsoleForm.cs
@@ -48,7 +48,7 @@ namespace RTCV.Common.Forms
         public LogConsoleForm(int maxLines = 1000, Layout layout = null, string fileName = null)
         {
             InitializeComponent();
-            LogConsole.InitializeCustomLogger(layout, fileName);
+            LogConsole.InitializeCustomLogger(maxLines, layout, fileName);
             this.FormClosing += LogConsoleForm_FormClosing;
         }
 

--- a/Source/Libraries/Common/Forms/LogConsoleForm.cs
+++ b/Source/Libraries/Common/Forms/LogConsoleForm.cs
@@ -41,7 +41,6 @@ namespace RTCV.Common.Forms
         /// <summary>
         /// Creates a LogConsoleForm using the global logger
         /// </summary>
-        /// <param name="maxLines">Maximum lines to display</param>
         /// <param name="layout">Layout</param>
         /// <param name="fileName">Optional file log</param>
         public LogConsoleForm(Layout layout = null, string fileName = null)

--- a/Source/Libraries/Common/Forms/LogConsoleForm.cs
+++ b/Source/Libraries/Common/Forms/LogConsoleForm.cs
@@ -38,12 +38,14 @@ namespace RTCV.Common.Forms
             LogConsole.InitializeFromGlobalLogger();
         }
 
+        #pragma warning disable CA1801,IDE0060 //maxLines is unused but should be left in for external plugins
         /// <summary>
         /// Creates a LogConsoleForm using the global logger
         /// </summary>
+        /// <param name="maxLines">Maximum lines to display</param>
         /// <param name="layout">Layout</param>
         /// <param name="fileName">Optional file log</param>
-        public LogConsoleForm(Layout layout = null, string fileName = null)
+        public LogConsoleForm(int maxLines = 1000, Layout layout = null, string fileName = null)
         {
             InitializeComponent();
             LogConsole.InitializeCustomLogger(layout, fileName);

--- a/Source/Libraries/Common/Forms/LogConsoleForm.cs
+++ b/Source/Libraries/Common/Forms/LogConsoleForm.cs
@@ -44,10 +44,10 @@ namespace RTCV.Common.Forms
         /// <param name="maxLines">Maximum lines to display</param>
         /// <param name="layout">Layout</param>
         /// <param name="fileName">Optional file log</param>
-        public LogConsoleForm(int maxLines = 1000, Layout layout = null, string fileName = null)
+        public LogConsoleForm(Layout layout = null, string fileName = null)
         {
             InitializeComponent();
-            LogConsole.InitializeCustomLogger(maxLines, layout, fileName);
+            LogConsole.InitializeCustomLogger(layout, fileName);
             this.FormClosing += LogConsoleForm_FormClosing;
         }
 

--- a/Source/Libraries/CorruptCore/Blast Generator Engines/RTC_StoreGenerator.cs
+++ b/Source/Libraries/CorruptCore/Blast Generator Engines/RTC_StoreGenerator.cs
@@ -5,7 +5,7 @@ namespace RTCV.CorruptCore
     public static class RTC_StoreGenerator
     {
         public static BlastLayer GenerateLayer(string note, string domain, long stepSize, long startAddress, long endAddress,
-            ulong param1, ulong param2, int precision, int lifetime, int executeFrame, bool loop, int seed, BGStoreMode mode)
+            ulong param1, int precision, int lifetime, int executeFrame, bool loop, int seed, BGStoreMode mode)
         {
             BlastLayer bl = new BlastLayer();
 
@@ -13,7 +13,7 @@ namespace RTCV.CorruptCore
             //We subtract 1 at the end as precision is 1,2,4, and we need to go 0,1,3
             for (long address = startAddress; address < endAddress; address = address + stepSize + precision - 1)
             {
-                BlastUnit bu = GenerateUnit(domain, address, param1, param2, stepSize, precision, lifetime, executeFrame, loop, mode, note, rand);
+                BlastUnit bu = GenerateUnit(domain, address, param1, stepSize, precision, lifetime, executeFrame, loop, mode, note, rand);
                 if (bu != null)
                 {
                     bl.Layer.Add(bu);
@@ -23,7 +23,7 @@ namespace RTCV.CorruptCore
             return bl;
         }
 
-        private static BlastUnit GenerateUnit(string domain, long address, ulong param1, ulong param2, long stepSize,
+        private static BlastUnit GenerateUnit(string domain, long address, ulong param1, long stepSize,
             int precision, int lifetime, int executeFrame, bool loop, BGStoreMode mode, string note, Random rand)
         {
             try

--- a/Source/Libraries/CorruptCore/BlastGeneratorProto.cs
+++ b/Source/Libraries/CorruptCore/BlastGeneratorProto.cs
@@ -53,7 +53,7 @@ namespace RTCV.CorruptCore
                     bl = RTC_ValueGenerator.GenerateLayer(Note, Domain, StepSize, StartAddress, EndAddress, Param1, Param2, Precision, Lifetime, ExecuteFrame, Loop, Seed, (BGValueMode)Enum.Parse(typeof(BGValueMode), Mode, true));
                     break;
                 case "Store":
-                    bl = RTC_StoreGenerator.GenerateLayer(Note, Domain, StepSize, StartAddress, EndAddress, Param1, Param2, Precision, Lifetime, ExecuteFrame, Loop, Seed, (BGStoreMode)Enum.Parse(typeof(BGStoreMode), Mode, true));
+                    bl = RTC_StoreGenerator.GenerateLayer(Note, Domain, StepSize, StartAddress, EndAddress, Param1, Precision, Lifetime, ExecuteFrame, Loop, Seed, (BGStoreMode)Enum.Parse(typeof(BGStoreMode), Mode, true));
                     break;
                 default:
                     return null;

--- a/Source/Libraries/CorruptCore/BlastTools.cs
+++ b/Source/Libraries/CorruptCore/BlastTools.cs
@@ -199,9 +199,8 @@
         /// Call from emulator side only
         /// </summary>
         /// <param name="blastLayers"></param>
-        /// <param name="sk"></param>
         /// <returns></returns>
-        public static List<BlastGeneratorProto> GenerateBlastLayersFromBlastGeneratorProtos(List<BlastGeneratorProto> blastLayers, StashKey sk)
+        public static List<BlastGeneratorProto> GenerateBlastLayersFromBlastGeneratorProtos(List<BlastGeneratorProto> blastLayers)
         {
             foreach (BlastGeneratorProto bgp in blastLayers)
             {

--- a/Source/Libraries/CorruptCore/BlastUnit.cs
+++ b/Source/Libraries/CorruptCore/BlastUnit.cs
@@ -543,7 +543,7 @@ namespace RTCV.CorruptCore
         /// If you want to execute a blastunit, add it to the execution pool using Apply()
         /// Returns false
         /// </summary>
-        public ExecuteState Execute(bool UseRealtime = true)
+        public ExecuteState Execute()
         {
             if (!IsEnabled)
             {
@@ -737,7 +737,7 @@ namespace RTCV.CorruptCore
                 if (StoreLimiterSource == StoreLimiterSource.ADDRESS || StoreLimiterSource == StoreLimiterSource.BOTH)
                 {
                     if (Filtering.LimiterPeekBytes(Address,
-                        Address + Precision, Domain, LimiterListHash, destMI))
+                        Address + Precision, LimiterListHash, destMI))
                     {
                         if (InvertLimiter)
                         {
@@ -757,7 +757,7 @@ namespace RTCV.CorruptCore
                     }
 
                     if (Filtering.LimiterPeekBytes(SourceAddress,
-                        SourceAddress + Precision, Domain, LimiterListHash, sourceMI))
+                        SourceAddress + Precision, LimiterListHash, sourceMI))
                     {
                         if (InvertLimiter)
                         {
@@ -771,7 +771,7 @@ namespace RTCV.CorruptCore
             else
             {
                 if (Filtering.LimiterPeekBytes(Address,
-                    Address + Precision, Domain, LimiterListHash, destMI))
+                    Address + Precision, LimiterListHash, destMI))
                 {
                     if (InvertLimiter)
                     {

--- a/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
+++ b/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
@@ -299,7 +299,7 @@ namespace RTCV.CorruptCore
                                     StockpileManager_EmuSide.LoadState_NET(sk, false);
                                 }
 
-                                returnList = BlastTools.GenerateBlastLayersFromBlastGeneratorProtos(blastGeneratorProtos, sk);
+                                returnList = BlastTools.GenerateBlastLayersFromBlastGeneratorProtos(blastGeneratorProtos);
                                 if (applyAfterCorrupt)
                                 {
                                     var bl = new BlastLayer();
@@ -476,7 +476,7 @@ namespace RTCV.CorruptCore
 
                                     for (long i = 0; i < mi.Size; i += listItemSize)
                                     {
-                                        if (Filtering.LimiterPeekBytes(i, i + listItemSize, mi.Name, limiterListHash, mi))
+                                        if (Filtering.LimiterPeekBytes(i, i + listItemSize, limiterListHash, mi))
                                         {
                                             for (var j = 0; j < listItemSize; j++)
                                             {

--- a/Source/Libraries/CorruptCore/Corruption Engines/RTC_ClusterEngine.cs
+++ b/Source/Libraries/CorruptCore/Corruption Engines/RTC_ClusterEngine.cs
@@ -177,13 +177,13 @@ namespace RTCV.CorruptCore
             {
                 for (int j = 0; j < chunkSize; j++)
                 {
-                    if (!Filtering.LimiterPeekBytes(safeAddress + (j * precision), safeAddress + (j * precision) + precision, domain, LimiterListHash, mi))
+                    if (!Filtering.LimiterPeekBytes(safeAddress + (j * precision), safeAddress + (j * precision) + precision, LimiterListHash, mi))
                     {
                         return null;
                     }
                 }
             }
-            else if (!Filtering.LimiterPeekBytes(filterAddress, filterAddress + precision, domain, LimiterListHash, mi))
+            else if (!Filtering.LimiterPeekBytes(filterAddress, filterAddress + precision, LimiterListHash, mi))
             {
                 return null;
             }

--- a/Source/Libraries/CorruptCore/Corruption Engines/RTC_VectorEngine.cs
+++ b/Source/Libraries/CorruptCore/Corruption Engines/RTC_VectorEngine.cs
@@ -46,7 +46,7 @@ namespace RTCV.CorruptCore
                 safeAddress = mi.Size - 8 + alignment; //If we're out of range, hit the last aligned address
             }
             //Enforce the safeaddress at generation
-            var matchBytes = Filtering.LimiterPeekAndGetBytes(safeAddress, safeAddress + 4, domain, LimiterListHash, mi);
+            var matchBytes = Filtering.LimiterPeekAndGetBytes(safeAddress, safeAddress + 4, LimiterListHash, mi);
             if (matchBytes != null)
             {
                 return new BlastUnit(Filtering.GetRandomConstant(ValueListHash, 4, matchBytes), domain, safeAddress, 4,

--- a/Source/Libraries/CorruptCore/Filtering.cs
+++ b/Source/Libraries/CorruptCore/Filtering.cs
@@ -203,7 +203,7 @@ namespace RTCV.CorruptCore
             return hashStr;
         }
 
-        public static bool LimiterPeekBytes(long startAddress, long endAddress, string domain, string hash, MemoryInterface mi)
+        public static bool LimiterPeekBytes(long startAddress, long endAddress, string hash, MemoryInterface mi)
         {
             //If we go outside of the domain, just return false
             if (endAddress > mi.Size)
@@ -236,7 +236,7 @@ namespace RTCV.CorruptCore
             return false;
         }
 
-        public static byte[] LimiterPeekAndGetBytes(long startAddress, long endAddress, string domain, string hash, MemoryInterface mi)
+        public static byte[] LimiterPeekAndGetBytes(long startAddress, long endAddress, string hash, MemoryInterface mi)
         {
             //If we go outside of the domain, just return false
             if (endAddress > mi.Size)

--- a/Source/Libraries/CorruptCore/MemoryDomains.cs
+++ b/Source/Libraries/CorruptCore/MemoryDomains.cs
@@ -1257,7 +1257,7 @@ namespace RTCV.CorruptCore
             }
         }
 
-        public string getCompositeFilename(string prefix)
+        public string getCompositeFilename()
         {
             if (CompositeFilenameDico.ContainsKey(Filename))
             {
@@ -1337,7 +1337,7 @@ namespace RTCV.CorruptCore
         {
             if (overrideWriteCopyMode)
             {
-                return Path.Combine(RtcCore.EmuDir, "FILEBACKUPS", getCompositeFilename("CORRUPT"));
+                return Path.Combine(RtcCore.EmuDir, "FILEBACKUPS", getCompositeFilename());
             }
             else
             {
@@ -1347,7 +1347,7 @@ namespace RTCV.CorruptCore
 
         public string getBackupFilename()
         {
-            return Path.Combine(RtcCore.EmuDir, "FILEBACKUPS", getCompositeFilename("BACKUP"));
+            return Path.Combine(RtcCore.EmuDir, "FILEBACKUPS", getCompositeFilename());
         }
 
         public override bool ResetWorkingFile()
@@ -1729,9 +1729,9 @@ namespace RTCV.CorruptCore
             return "Multiple Files";
         }
 
-        public string getCompositeFilename(string prefix)
+        public string getCompositeFilename()
         {
-            return string.Join("|", FileInterfaces.Select(it => it.getCompositeFilename(prefix)));
+            return string.Join("|", FileInterfaces.Select(it => it.getCompositeFilename()));
         }
 
         public string getCorruptFilename(bool overrideWriteCopyMode = false)

--- a/Source/Libraries/CorruptCore/StockpileManager_EmuSide.cs
+++ b/Source/Libraries/CorruptCore/StockpileManager_EmuSide.cs
@@ -81,7 +81,7 @@
             return true;
         }
 
-        public static StashKey SaveStateLess_NET(StashKey _sk = null, bool threadSave = false)
+        public static StashKey SaveStateLess_NET(StashKey _sk = null)
         {
             string Key;
             //string statePath = "";
@@ -111,7 +111,7 @@
             return sk;
         }
 
-        public static StashKey SaveState_NET(StashKey _sk = null, bool threadSave = false)
+        public static StashKey SaveState_NET(StashKey _sk = null)
         {
             string Key;
             string statePath;

--- a/Source/Libraries/CorruptCore/StockpileManager_UISide.cs
+++ b/Source/Libraries/CorruptCore/StockpileManager_UISide.cs
@@ -209,7 +209,7 @@ namespace RTCV.CorruptCore
 
             bool isCorruptionApplied = false;
 
-            if (!LoadState(sk, false))
+            if (!LoadState(sk, true, false))
             {
                 return isCorruptionApplied;
             }
@@ -304,9 +304,9 @@ namespace RTCV.CorruptCore
             return false;
         }
 
-        public static bool LoadState(StashKey sk, bool applyBlastLayer = true)
+        public static bool LoadState(StashKey sk, bool reloadRom = true, bool applyBlastLayer = true)
         {
-            bool success = LocalNetCoreRouter.QueryRoute<bool>(NetcoreCommands.CORRUPTCORE, NetcoreCommands.REMOTE_LOADSTATE, new object[] { sk, true, applyBlastLayer }, true);
+            bool success = LocalNetCoreRouter.QueryRoute<bool>(NetcoreCommands.CORRUPTCORE, NetcoreCommands.REMOTE_LOADSTATE, new object[] { sk, reloadRom, applyBlastLayer }, true);
             return success;
         }
 

--- a/Source/Libraries/CorruptCore/StockpileManager_UISide.cs
+++ b/Source/Libraries/CorruptCore/StockpileManager_UISide.cs
@@ -209,7 +209,7 @@ namespace RTCV.CorruptCore
 
             bool isCorruptionApplied = false;
 
-            if (!LoadState(sk, true, false))
+            if (!LoadState(sk, false))
             {
                 return isCorruptionApplied;
             }
@@ -304,13 +304,13 @@ namespace RTCV.CorruptCore
             return false;
         }
 
-        public static bool LoadState(StashKey sk, bool reloadRom = true, bool applyBlastLayer = true)
+        public static bool LoadState(StashKey sk, bool applyBlastLayer = true)
         {
             bool success = LocalNetCoreRouter.QueryRoute<bool>(NetcoreCommands.CORRUPTCORE, NetcoreCommands.REMOTE_LOADSTATE, new object[] { sk, true, applyBlastLayer }, true);
             return success;
         }
 
-        public static StashKey SaveState(StashKey sk = null, bool threadSave = false)
+        public static StashKey SaveState(StashKey sk = null)
         {
             bool UseSavestates = (bool)AllSpec.VanguardSpec[VSPEC.SUPPORTS_SAVESTATES];
 

--- a/Source/Libraries/NetCore/DebugInfo/CloudDebug_Form.cs
+++ b/Source/Libraries/NetCore/DebugInfo/CloudDebug_Form.cs
@@ -220,7 +220,7 @@ namespace RTCV.NetCore
                 string filename = keyparts[0];
                 string password = keyparts[1];
 
-                string downloadfilepath = CloudTransfer.CloudLoad(filename, password);
+                string downloadfilepath = CloudTransfer.CloudLoad(filename);
 
                 if (downloadfilepath == null)
                 {
@@ -344,7 +344,7 @@ namespace RTCV.NetCore
     {
         private static string CorruptCloudServer = "http://cc.r5x.cc/rtc/debug";
 
-        public static string CloudLoad(string filename, string password)
+        public static string CloudLoad(string filename)
         {
             string remoteUri = CorruptCloudServer + "/FILES/";
 

--- a/Source/Libraries/NetCore/SyncObjectSingleton.cs
+++ b/Source/Libraries/NetCore/SyncObjectSingleton.cs
@@ -75,7 +75,7 @@
             }
         }
 
-        public static void SyncObjectExecute(Form sync, Action<object, EventArgs> a, object[] args = null)
+        public static void SyncObjectExecute(Form sync, Action<object, EventArgs> a)
         {
             if (sync.InvokeRequired)
             {

--- a/Source/Libraries/PluginHost/Host.cs
+++ b/Source/Libraries/PluginHost/Host.cs
@@ -28,7 +28,7 @@ namespace RTCV.PluginHost
             AppDomain.CurrentDomain.AssemblyLoad += CurrentDomain_AssemblyLoad;
         }
 
-        private void initialize(string[] pluginDirs, RTCSide side)
+        private void initialize(string[] pluginDirs)
         {
             var catalog = new AggregateCatalog();
             foreach (var dir in pluginDirs)
@@ -55,7 +55,7 @@ namespace RTCV.PluginHost
                 logger.Error(new InvalidOperationException("Host has already been started."));
             }
 
-            initialize(pluginDirs, side);
+            initialize(pluginDirs);
 
             foreach (var p in plugins)
             {


### PR DESCRIPTION
This change fixes `CA1801`.

There were lots of functions in the code that had parameters that weren't used in the function body. I fixed all of those instances.