### PR TITLE
Fixed CA1815 - Structs should override comparison operators

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -291,9 +291,6 @@ dotnet_diagnostic.CA1812.severity = none
 # .ctor uses a multidimensional array. Replace it with a jagged array if possible.
 dotnet_diagnostic.CA1814.severity = none
 
-# KeyEvent should override method
-dotnet_diagnostic.CA1815.severity = none
-
 # Change Dispose() to call GC.SuppressFinalize(object). This will prevent derived types that introduce a finalizer from needing to re-implement 'IDisposable' to call it.
 dotnet_diagnostic.CA1816.severity = none
 

--- a/Source/Frontend/UI/Input/Keyboard.cs
+++ b/Source/Frontend/UI/Input/Keyboard.cs
@@ -75,6 +75,7 @@ namespace RTCV.UI.Input
             }
         }
 
+        #pragma warning disable CA1815 //KeyEvent won't be used in comparison
         public struct KeyEvent
         {
             public Key Key;

--- a/Source/Libraries/CorruptCore/Diff.cs
+++ b/Source/Libraries/CorruptCore/Diff.cs
@@ -78,6 +78,7 @@
 
     public class Diff
     {
+        #pragma warning disable CA1815 //Item won't be used in comparison
         /// <summary>details of one difference.</summary>
         public struct Item
         {


### PR DESCRIPTION
Per [the documentation for CA1815](https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1815?view=vs-2019), violations can be safely ignored if the struct is never used for comparison. In this case, neither violating struct is used in a comparison. I disabled the warning for each of the non-violations.