### PR TITLE
[Refactor] Merge duplicate Clamp<T> implementations

### DIFF
--- a/Source/Frontend/UI/UI_Extensions.cs
+++ b/Source/Frontend/UI/UI_Extensions.cs
@@ -414,30 +414,6 @@ namespace RTCV.UI
         {
             return $"{n:X}";
         }
-
-        /// <summary>
-        /// Force the value to be strictly between min and max (both exclued)
-        /// </summary>
-        /// <typeparam name="T">Anything that implements <see cref="IComparable{T}"/></typeparam>
-        /// <param name="val">Value that will be clamped</param>
-        /// <param name="min">Minimum allowed</param>
-        /// <param name="max">Maximum allowed</param>
-        /// <returns>The value if strictly between min and max; otherwise min (or max depending of what is passed)</returns>
-        public static T Clamp<T>(this T val, T min, T max)
-            where T : IComparable<T>
-        {
-            if (val.CompareTo(min) < 0)
-            {
-                return min;
-            }
-
-            if (val.CompareTo(max) > 0)
-            {
-                return max;
-            }
-
-            return val;
-        }
     }
 
     /// <summary>

--- a/Source/Libraries/Common/Common.csproj
+++ b/Source/Libraries/Common/Common.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Logging.cs" />
     <Compile Include="Extensions\RandomExtensions.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
+    <Compile Include="Extensions\TExtensions.cs" />
     <Compile Include="Objects\OperationResults.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StaticTools.cs" />

--- a/Source/Libraries/Common/Extensions/TExtensions.cs
+++ b/Source/Libraries/Common/Extensions/TExtensions.cs
@@ -1,0 +1,31 @@
+namespace RTCV.Common
+{
+    using System;
+
+    public static class TExtensions
+    {
+        /// <summary>
+        /// Force the value to be strictly between min and max (both exclued)
+        /// </summary>
+        /// <typeparam name="T">Anything that implements <see cref="IComparable{T}"/></typeparam>
+        /// <param name="val">Value that will be clamped</param>
+        /// <param name="min">Minimum allowed</param>
+        /// <param name="max">Maximum allowed</param>
+        /// <returns>The value if strictly between min and max; otherwise min (or max depending of what is passed)</returns>
+        public static T Clamp<T>(this T val, T min, T max)
+            where T : IComparable<T>
+        {
+            if (val.CompareTo(min) < 0)
+            {
+                return min;
+            }
+
+            if (val.CompareTo(max) > 0)
+            {
+                return max;
+            }
+
+            return val;
+        }
+    }
+}

--- a/Source/Libraries/CorruptCore/CorruptCore_Extensions.cs
+++ b/Source/Libraries/CorruptCore/CorruptCore_Extensions.cs
@@ -914,29 +914,6 @@ namespace RTCV.CorruptCore
         }
         #endregion
 
-        /// <summary>
-        /// Force the value to be strictly between min and max (both exclued)
-        /// </summary>
-        /// <typeparam name="T">Anything that implements <see cref="IComparable{T}"/></typeparam>
-        /// <param name="val">Value that will be clamped</param>
-        /// <param name="min">Minimum allowed</param>
-        /// <param name="max">Maximum allowed</param>
-        /// <returns>The value if strictly between min and max; otherwise min (or max depending of what is passed)</returns>
-        public static T Clamp<T>(this T val, T min, T max)
-            where T : IComparable<T>
-        {
-            if (val.CompareTo(min) < 0)
-            {
-                return min;
-            }
-
-            if (val.CompareTo(max) > 0)
-            {
-                return max;
-            }
-
-            return val;
-        }
         #region Image CorruptCore_Extensions
 
         public static byte[] ImageToByteArray(System.Drawing.Image imageIn, System.Drawing.Imaging.ImageFormat imageFormat)


### PR DESCRIPTION
Both `UI` and `CorruptCore` had a `Clamp<T>` implementation. I moved this implementation to the `Common` library.

This change may break dependants if they are using this helper function.