### PR TITLE
Fix CA2200 - Rethrow to preserve stack details

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -313,9 +313,6 @@ dotnet_diagnostic.CA2008.severity = none
 # Specify marshaling for P/Invoke string arguments
 dotnet_diagnostic.CA2101.severity = none
 
-# Re-throwing caught exception changes stack information
-dotnet_diagnostic.CA2200.severity = none
-
 # Non-constant fields should not be visible
 dotnet_diagnostic.CA2211.severity = none
 

--- a/Source/Libraries/NetCore/Connector.cs
+++ b/Source/Libraries/NetCore/Connector.cs
@@ -44,10 +44,10 @@ namespace RTCV.NetCore
                 tcp = new TCPLink(spec);
                 watch = new ReturnWatch(spec);
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 Kill();
-                throw ex;
+                throw;
             }
         }
 

--- a/Source/Libraries/NetCore/UDPLink.cs
+++ b/Source/Libraries/NetCore/UDPLink.cs
@@ -130,7 +130,7 @@ namespace RTCV.NetCore
                         }
                         else
                         {
-                            throw ex;
+                            throw;
                         }
                     }
                     if (bytes != null)


### PR DESCRIPTION
Per the [documentation for CA2200](https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2200?view=vs-2019), rethrown exceptions should be thrown implicitly to avoid overriding stack information.

This change fixes all violations of CA2200.