### PR TITLE
[Refactor] Input class breakup

### DIFF
--- a/Source/Frontend/UI/Components/Controls/InputCompositeWidget.cs
+++ b/Source/Frontend/UI/Components/Controls/InputCompositeWidget.cs
@@ -82,21 +82,21 @@ namespace RTCV.UI.Components.Controls
 
         private void DropdownMenu_ItemClicked(object sender, ToolStripItemClickedEventArgs e)
         {
-            Input.Input.ModifierKeys mods = new Input.Input.ModifierKeys();
+            Input.ModifierKeys mods = new Input.ModifierKeys();
 
             if ((ModifierKeys & Keys.Shift) != 0)
             {
-                mods |= Input.Input.ModifierKeys.Shift;
+                mods |= Input.ModifierKeys.Shift;
             }
 
             if ((ModifierKeys & Keys.Control) != 0)
             {
-                mods |= Input.Input.ModifierKeys.Control;
+                mods |= Input.ModifierKeys.Control;
             }
 
             if ((ModifierKeys & Keys.Alt) != 0)
             {
-                mods |= Input.Input.ModifierKeys.Alt;
+                mods |= Input.ModifierKeys.Alt;
             }
 
             var lb = new Input.LogicalButton(e.ClickedItem.Text, mods);

--- a/Source/Frontend/UI/Components/Controls/InputCompositeWidget.cs
+++ b/Source/Frontend/UI/Components/Controls/InputCompositeWidget.cs
@@ -99,7 +99,7 @@ namespace RTCV.UI.Components.Controls
                 mods |= Input.Input.ModifierKeys.Alt;
             }
 
-            var lb = new Input.Input.LogicalButton(e.ClickedItem.Text, mods);
+            var lb = new Input.LogicalButton(e.ClickedItem.Text, mods);
 
             widget.SetBinding(lb.ToString());
         }

--- a/Source/Frontend/UI/Input/Input.cs
+++ b/Source/Frontend/UI/Input/Input.cs
@@ -98,58 +98,6 @@
             Press, Release
         }
 
-        public struct LogicalButton : IEquatable<LogicalButton>
-        {
-            public LogicalButton(string button, ModifierKeys modifiers)
-            {
-                Button = button;
-                Modifiers = modifiers;
-            }
-
-            public readonly string Button;
-            public readonly ModifierKeys Modifiers;
-
-            public bool Alt { get { return ((Modifiers & ModifierKeys.Alt) != 0); } }
-            public bool Control { get { return ((Modifiers & ModifierKeys.Control) != 0); } }
-            public bool Shift { get { return ((Modifiers & ModifierKeys.Shift) != 0); } }
-
-            public override string ToString()
-            {
-                string ret = "";
-                if (Control) ret += "Ctrl+";
-                if (Alt) ret += "Alt+";
-                if (Shift) ret += "Shift+";
-                ret += Button;
-                return ret;
-            }
-
-            public override bool Equals(object obj)
-            {
-                var other = (LogicalButton)obj;
-                return Equals(other);
-            }
-
-            public bool Equals(LogicalButton other)
-            {
-                return other == this;
-            }
-
-            public override int GetHashCode()
-            {
-                return Button.GetHashCode() ^ Modifiers.GetHashCode();
-            }
-
-            public static bool operator ==(LogicalButton lhs, LogicalButton rhs)
-            {
-                return lhs.Button == rhs.Button && lhs.Modifiers == rhs.Modifiers;
-            }
-
-            public static bool operator !=(LogicalButton lhs, LogicalButton rhs)
-            {
-                return !(lhs == rhs);
-            }
-        }
-
         public class InputEvent
         {
             public LogicalButton LogicalButton;

--- a/Source/Frontend/UI/Input/Input.cs
+++ b/Source/Frontend/UI/Input/Input.cs
@@ -30,30 +30,6 @@
 
         readonly HashSet<System.Windows.Forms.Control> WantingMouseFocus = new HashSet<System.Windows.Forms.Control>();
 
-        [Flags]
-        public enum ModifierKeys
-        {
-            // Summary:
-            //     The bitmask to extract modifiers from a key value.
-            Modifiers = -65536,
-
-            // Summary:
-            //     No key pressed.
-            None = 0,
-
-            // Summary:
-            //     The SHIFT modifier key.
-            Shift = 65536,
-
-            // Summary:
-            //     The CTRL modifier key.
-            Control = 131072,
-
-            // Summary:
-            //     The ALT modifier key.
-            Alt = 262144,
-        }
-
         public static Input Instance { get; private set; }
         readonly Thread UpdateThread;
         private bool KillUpdateThread = false;

--- a/Source/Frontend/UI/Input/LogicalButton.cs
+++ b/Source/Frontend/UI/Input/LogicalButton.cs
@@ -1,24 +1,21 @@
 namespace RTCV.UI.Input
 {
     using System;
-    using System.Collections.Generic;
-    using System.Threading;
-    using RTCV.NetCore;
 
     public struct LogicalButton : IEquatable<LogicalButton>
     {
-        public LogicalButton(string button, Input.ModifierKeys modifiers)
+        public LogicalButton(string button, ModifierKeys modifiers)
         {
             Button = button;
             Modifiers = modifiers;
         }
 
         public readonly string Button;
-        public readonly Input.ModifierKeys Modifiers;
+        public readonly ModifierKeys Modifiers;
 
-        public bool Alt { get { return ((Modifiers & Input.ModifierKeys.Alt) != 0); } }
-        public bool Control { get { return ((Modifiers & Input.ModifierKeys.Control) != 0); } }
-        public bool Shift { get { return ((Modifiers & Input.ModifierKeys.Shift) != 0); } }
+        public bool Alt { get { return ((Modifiers & ModifierKeys.Alt) != 0); } }
+        public bool Control { get { return ((Modifiers & ModifierKeys.Control) != 0); } }
+        public bool Shift { get { return ((Modifiers & ModifierKeys.Shift) != 0); } }
 
         public override string ToString()
         {

--- a/Source/Frontend/UI/Input/LogicalButton.cs
+++ b/Source/Frontend/UI/Input/LogicalButton.cs
@@ -1,0 +1,60 @@
+namespace RTCV.UI.Input
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using RTCV.NetCore;
+
+    public struct LogicalButton : IEquatable<LogicalButton>
+    {
+        public LogicalButton(string button, Input.ModifierKeys modifiers)
+        {
+            Button = button;
+            Modifiers = modifiers;
+        }
+
+        public readonly string Button;
+        public readonly Input.ModifierKeys Modifiers;
+
+        public bool Alt { get { return ((Modifiers & Input.ModifierKeys.Alt) != 0); } }
+        public bool Control { get { return ((Modifiers & Input.ModifierKeys.Control) != 0); } }
+        public bool Shift { get { return ((Modifiers & Input.ModifierKeys.Shift) != 0); } }
+
+        public override string ToString()
+        {
+            string ret = "";
+            if (Control) ret += "Ctrl+";
+            if (Alt) ret += "Alt+";
+            if (Shift) ret += "Shift+";
+            ret += Button;
+            return ret;
+        }
+
+        public override bool Equals(object obj)
+        {
+            var other = (LogicalButton)obj;
+            return Equals(other);
+        }
+
+        public bool Equals(LogicalButton other)
+        {
+            return other == this;
+        }
+
+        public override int GetHashCode()
+        {
+            return Button.GetHashCode() ^ Modifiers.GetHashCode();
+        }
+
+        public static bool operator ==(LogicalButton lhs, LogicalButton rhs)
+        {
+            return lhs.Button == rhs.Button && lhs.Modifiers == rhs.Modifiers;
+        }
+
+        public static bool operator !=(LogicalButton lhs, LogicalButton rhs)
+        {
+            return !(lhs == rhs);
+        }
+    }
+
+}

--- a/Source/Frontend/UI/Input/LogicalButton.cs
+++ b/Source/Frontend/UI/Input/LogicalButton.cs
@@ -53,5 +53,4 @@ namespace RTCV.UI.Input
             return !(lhs == rhs);
         }
     }
-
 }

--- a/Source/Frontend/UI/Input/ModifierKeys.cs
+++ b/Source/Frontend/UI/Input/ModifierKeys.cs
@@ -1,0 +1,28 @@
+namespace RTCV.UI.Input
+{
+    using System;
+
+    [Flags]
+    public enum ModifierKeys
+    {
+        // Summary:
+        //     The bitmask to extract modifiers from a key value.
+        Modifiers = -65536,
+
+        // Summary:
+        //     No key pressed.
+        None = 0,
+
+        // Summary:
+        //     The SHIFT modifier key.
+        Shift = 65536,
+
+        // Summary:
+        //     The CTRL modifier key.
+        Control = 131072,
+
+        // Summary:
+        //     The ALT modifier key.
+        Alt = 262144,
+    }
+}

--- a/Source/Frontend/UI/UI.csproj
+++ b/Source/Frontend/UI/UI.csproj
@@ -382,6 +382,7 @@
     <Compile Include="Input\IPCKeyInput.cs" />
     <Compile Include="Input\Keyboard.cs" />
     <Compile Include="Input\LogicalButton.cs" />
+    <Compile Include="Input\ModifierKeys.cs" />
     <Compile Include="Input\WorkingDictionary.cs" />
     <Compile Include="Modular\UI_CanvasForm.cs">
       <SubType>Form</SubType>

--- a/Source/Frontend/UI/UI.csproj
+++ b/Source/Frontend/UI/UI.csproj
@@ -381,6 +381,7 @@
     <Compile Include="Input\Input.cs" />
     <Compile Include="Input\IPCKeyInput.cs" />
     <Compile Include="Input\Keyboard.cs" />
+    <Compile Include="Input\LogicalButton.cs" />
     <Compile Include="Input\WorkingDictionary.cs" />
     <Compile Include="Modular\UI_CanvasForm.cs">
       <SubType>Form</SubType>


### PR DESCRIPTION
`RTCV.UI.Input.Input` is a class which has some types/classes defined inside of it. This generally isn't in good form, and violates [CA1034](https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1034?view=vs-2019).

This change moves some types/classes defined inside of `RTCV.UI.Input.Input` to their own files.

This change will likely break dependants, so I'm listing this as a draft until we have a stronger CI validation pipeline.