### PR TITLE
[Cleanup] HexTextBox._maxSize cleanup

### DIFF
--- a/Source/Frontend/UI/Components/Controls/HexTextBox.cs
+++ b/Source/Frontend/UI/Components/Controls/HexTextBox.cs
@@ -15,7 +15,6 @@ namespace RTCV.UI.Components.Controls
     public class HexTextBox : TextBox, INumberBox
     {
         private string _addressFormatStr = "";
-        private long? _maxSize;
         private bool _nullable = true;
 
         public HexTextBox()
@@ -26,11 +25,6 @@ namespace RTCV.UI.Components.Controls
         public bool Nullable { get => _nullable; set => _nullable = value; }
         public long GetMax()
         {
-            if (_maxSize.HasValue)
-            {
-                return _maxSize.Value;
-            }
-
             return ((long)1 << (4 * MaxLength)) - 1;
         }
 


### PR DESCRIPTION
`_maxSize` never has a value set. I feel like this may be a bug.