### PR TITLE
[Refactor] Move InputEvent to its own file

### DIFF
--- a/Source/Frontend/UI/Input/Input.cs
+++ b/Source/Frontend/UI/Input/Input.cs
@@ -69,22 +69,6 @@
             GamePad.Cleanup();
         }
 
-        public enum InputEventType
-        {
-            Press, Release
-        }
-
-        public class InputEvent
-        {
-            public LogicalButton LogicalButton;
-            public InputEventType EventType;
-
-            public override string ToString()
-            {
-                return string.Format("{0}:{1}", EventType.ToString(), LogicalButton.ToString());
-            }
-        }
-
         private readonly WorkingDictionary<string, object> ModifierState = new WorkingDictionary<string, object>();
         private readonly WorkingDictionary<string, bool> LastState = new WorkingDictionary<string, bool>();
         private readonly WorkingDictionary<string, bool> UnpressState = new WorkingDictionary<string, bool>();

--- a/Source/Frontend/UI/Input/InputEvent.cs
+++ b/Source/Frontend/UI/Input/InputEvent.cs
@@ -1,0 +1,18 @@
+namespace RTCV.UI.Input
+{
+    public enum InputEventType
+    {
+        Press, Release
+    }
+
+    public class InputEvent
+    {
+        public LogicalButton LogicalButton;
+        public InputEventType EventType;
+
+        public override string ToString()
+        {
+            return string.Format("{0}:{1}", EventType.ToString(), LogicalButton.ToString());
+        }
+    }
+}

--- a/Source/Frontend/UI/UI.csproj
+++ b/Source/Frontend/UI/UI.csproj
@@ -381,6 +381,7 @@
     <Compile Include="Input\Gamepad.cs" />
     <Compile Include="Input\Gamepad360.cs" />
     <Compile Include="Input\Input.cs" />
+    <Compile Include="Input\InputEvent.cs" />
     <Compile Include="Input\IPCKeyInput.cs" />
     <Compile Include="Input\Keyboard.cs" />
     <Compile Include="Input\LogicalButton.cs" />

--- a/Source/Frontend/UI/UICore.cs
+++ b/Source/Frontend/UI/UICore.cs
@@ -566,7 +566,7 @@ namespace RTCV.UI
                         var triggers = Input.Bindings.SearchBindings(ie.LogicalButton.ToString());
 
                         bool handled = false;
-                        if (ie.EventType == RTCV.UI.Input.Input.InputEventType.Press)
+                        if (ie.EventType == RTCV.UI.Input.InputEventType.Press)
                         {
                             triggers.Aggregate(handled, (current, trigger) => current | CheckHotkey(trigger));
                         }


### PR DESCRIPTION
Per CA1034, type definitions shouldn't be nested. `InputEvent` and `InputEventType` have definitions nested inside of the `Input` class.