### PR TITLE
[Refactor] Breakup CorruptCoreConnector.OnMessageReceived into helper functions

### DIFF
--- a/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
+++ b/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
@@ -64,7 +64,7 @@ namespace RTCV.CorruptCore
 
                     //Vanguard sent a spec update
                     case REMOTE_PUSHVANGUARDSPECUPDATE:
-                        RTCV.NetCore.AllSpec.VanguardSpec?.Update((PartialSpec)advancedMessage.objectValue, false);
+                        AllSpec.VanguardSpec?.Update((PartialSpec)advancedMessage.objectValue, false);
                         break;
 
                     //UI sent a copy of the CorruptCore spec
@@ -93,24 +93,7 @@ namespace RTCV.CorruptCore
                         }
 
                     case REMOTE_OPENHEXEDITOR:
-                        {
-                            if ((bool?)AllSpec.VanguardSpec[VSPEC.USE_INTEGRATED_HEXEDITOR] ?? false)
-                            {
-                              LocalNetCoreRouter.Route(NetcoreCommands.VANGUARD, NetcoreCommands.REMOTE_OPENHEXEDITOR, true);
-                            }
-                            else
-                            {
-                                //Route it to the plugin if loaded
-                                if (RtcCore.PluginHost.LoadedPlugins.Any(x => x.Name == "Hex Editor"))
-                                {
-                                    LocalNetCoreRouter.Route("HEXEDITOR", NetcoreCommands.REMOTE_OPENHEXEDITOR, true);
-                                }
-                                else
-                                {
-                                    MessageBox.Show("The current Vanguard implementation does not include a\n hex editor & the hex editor plugin isn't loaded. Aborting.");
-                                }
-                            }
-                        }
+                        OpenHexEditor();
                         break;
 
                     case EMU_OPEN_HEXEDITOR_ADDRESS:
@@ -165,7 +148,7 @@ namespace RTCV.CorruptCore
                     case REMOTE_LOADSTATE:
                         {
                             var valueAsObjectArr = advancedMessage.objectValue as object[];
-                            LoadState(valueAsObjectArr);
+                            LoadState(valueAsObjectArr, ref e);
                         }
                         break;
                     case REMOTE_SAVESTATE:
@@ -432,7 +415,7 @@ namespace RTCV.CorruptCore
             }
         }
 
-        private void LoadState(object[] valueAsObjectArr)
+        private void LoadState(object[] valueAsObjectArr, ref NetCoreEventArgs e)
         {
             lock (loadLock)
             {
@@ -462,6 +445,26 @@ namespace RTCV.CorruptCore
                     SyncObjectSingleton.EmuThreadExecute(a, false);
                 }
                 e.setReturnValue(returnValue);
+            }
+        }
+
+        private static void OpenHexEditor()
+        {
+            if ((bool?)AllSpec.VanguardSpec[VSPEC.USE_INTEGRATED_HEXEDITOR] ?? false)
+            {
+                LocalNetCoreRouter.Route(NetcoreCommands.VANGUARD, NetcoreCommands.REMOTE_OPENHEXEDITOR, true);
+            }
+            else
+            {
+                //Route it to the plugin if loaded
+                if (RtcCore.PluginHost.LoadedPlugins.Any(x => x.Name == "Hex Editor"))
+                {
+                    LocalNetCoreRouter.Route("HEXEDITOR", NetcoreCommands.REMOTE_OPENHEXEDITOR, true);
+                }
+                else
+                {
+                    MessageBox.Show("The current Vanguard implementation does not include a\n hex editor & the hex editor plugin isn't loaded. Aborting.");
+                }
             }
         }
 

--- a/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
+++ b/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
@@ -271,20 +271,7 @@ namespace RTCV.CorruptCore
                         break;
 
                     case REMOTE_LOADPLUGINS:
-                        SyncObjectSingleton.FormExecute(() =>
-                        {
-                            var emuPluginDir = string.Empty;
-                            try
-                            {
-                                emuPluginDir = System.IO.Path.Combine(RtcCore.EmuDir, "RTC", "PLUGINS");
-                            }
-                            catch (Exception e)
-                            {
-                                RTCV.Common.Logging.GlobalLogger.Error(e, "Unable to find plugin dir in {dir}", RtcCore.EmuDir + "\\RTC" + "\\PLUGINS");
-                            }
-                            RtcCore.LoadPlugins(new[] { RtcCore.PluginDir,  emuPluginDir });
-                        });
-
+                        LoadPlugins();
                         break;
                     case REMOTE_REMOVEEXCESSINFINITESTEPUNITS:
                         SyncObjectSingleton.FormExecute(() => StepActions.RemoveExcessInfiniteStepUnits());
@@ -588,6 +575,23 @@ namespace RTCV.CorruptCore
 
                 e.setReturnValue(allLegalAdresses.ToArray());
             }
+        }
+
+        private static void LoadPlugins()
+        {
+            SyncObjectSingleton.FormExecute(() =>
+                {
+                    var emuPluginDir = string.Empty;
+                    try
+                    {
+                        emuPluginDir = System.IO.Path.Combine(RtcCore.EmuDir, "RTC", "PLUGINS");
+                    }
+                    catch (Exception e)
+                    {
+                        RTCV.Common.Logging.GlobalLogger.Error(e, "Unable to find plugin dir in {dir}", RtcCore.EmuDir + "\\RTC" + "\\PLUGINS");
+                    }
+                    RtcCore.LoadPlugins(new[] { RtcCore.PluginDir,  emuPluginDir });
+                });
         }
 
         public void Kill()

--- a/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
+++ b/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
@@ -308,7 +308,7 @@ namespace RTCV.CorruptCore
             }
         }
 
-        private void PushCorruptCoreSpec(PartialSpec partialSpec, ref NetCoreEventArgs e)
+        private static void PushCorruptCoreSpec(PartialSpec partialSpec, ref NetCoreEventArgs e)
         {
             SyncObjectSingleton.FormExecute(() =>
             {
@@ -354,7 +354,7 @@ namespace RTCV.CorruptCore
             }
         }
 
-        private void LoadState(object[] valueAsObjectArr, ref NetCoreEventArgs e)
+        private static void LoadState(object[] valueAsObjectArr, ref NetCoreEventArgs e)
         {
             lock (loadLock)
             {
@@ -427,7 +427,7 @@ namespace RTCV.CorruptCore
             }
         }
 
-        private void BlastGeneratorBlast(object[] valueAsObjectArr, ref NetCoreEventArgs e)
+        private static void BlastGeneratorBlast(object[] valueAsObjectArr, ref NetCoreEventArgs e)
         {
             List<BlastGeneratorProto> returnList = null;
             var sk = (StashKey)valueAsObjectArr[0];
@@ -476,7 +476,7 @@ namespace RTCV.CorruptCore
             e.setReturnValue(returnList);
         }
 
-        private void GenerateBlastLayer(NetCoreAdvancedMessage advancedMessage, ref NetCoreEventArgs e)
+        private static void GenerateBlastLayer(NetCoreAdvancedMessage advancedMessage, ref NetCoreEventArgs e)
         {
             var val = advancedMessage.objectValue as object[];
             var sk = val[0] as StashKey;
@@ -529,7 +529,7 @@ namespace RTCV.CorruptCore
             }
         }
 
-        private void ApplyBlastLayer(NetCoreAdvancedMessage advancedMessage)
+        private static void ApplyBlastLayer(NetCoreAdvancedMessage advancedMessage)
         {
             var temp = advancedMessage.objectValue as object[];
             var bl = (BlastLayer)temp[0];

--- a/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
+++ b/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
@@ -97,25 +97,8 @@ namespace RTCV.CorruptCore
                         break;
 
                     case EMU_OPEN_HEXEDITOR_ADDRESS:
-                        {
-                            if ((bool?)AllSpec.VanguardSpec[VSPEC.USE_INTEGRATED_HEXEDITOR] ?? false)
-                            {
-                                LocalNetCoreRouter.Route(NetcoreCommands.VANGUARD, NetcoreCommands.EMU_OPEN_HEXEDITOR_ADDRESS, advancedMessage.objectValue, true);
-                            }
-                            else
-                            {
-                                //Route it to the plugin if loaded
-                                if (RtcCore.PluginHost.LoadedPlugins.Any(x => x.Name == "Hex Editor"))
-                                {
-                                    LocalNetCoreRouter.Route("HEXEDITOR", NetcoreCommands.EMU_OPEN_HEXEDITOR_ADDRESS, advancedMessage.objectValue, true);
-                                }
-                                else
-                                {
-                                    MessageBox.Show("The current Vanguard implementation does not include a\n hex editor & the hex editor plugin isn't loaded. Aborting.");
-                                }
-                            }
-                            break;
-                        }
+                        OpenHexEditorAddress(advancedMessage.objectValue);
+                        break;
 
                     case MANUALBLAST:
                         RtcCore.GenerateAndBlast();
@@ -460,6 +443,26 @@ namespace RTCV.CorruptCore
                 if (RtcCore.PluginHost.LoadedPlugins.Any(x => x.Name == "Hex Editor"))
                 {
                     LocalNetCoreRouter.Route("HEXEDITOR", NetcoreCommands.REMOTE_OPENHEXEDITOR, true);
+                }
+                else
+                {
+                    MessageBox.Show("The current Vanguard implementation does not include a\n hex editor & the hex editor plugin isn't loaded. Aborting.");
+                }
+            }
+        }
+
+        private static void OpenHexEditorAddress(object objectValue)
+        {
+            if ((bool?)AllSpec.VanguardSpec[VSPEC.USE_INTEGRATED_HEXEDITOR] ?? false)
+            {
+                LocalNetCoreRouter.Route(NetcoreCommands.VANGUARD, NetcoreCommands.EMU_OPEN_HEXEDITOR_ADDRESS, objectValue, true);
+            }
+            else
+            {
+                //Route it to the plugin if loaded
+                if (RtcCore.PluginHost.LoadedPlugins.Any(x => x.Name == "Hex Editor"))
+                {
+                    LocalNetCoreRouter.Route("HEXEDITOR", NetcoreCommands.EMU_OPEN_HEXEDITOR_ADDRESS, objectValue, true);
                 }
                 else
                 {

--- a/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
+++ b/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
@@ -175,30 +175,16 @@ namespace RTCV.CorruptCore
                         }
 
                     case MANUALBLAST:
-                        {
-                            RtcCore.GenerateAndBlast();
-                        }
+                        RtcCore.GenerateAndBlast();
                         break;
 
                     case GENERATEBLASTLAYER:
-                        {
-                            GenerateBlastLayer(advancedMessage, ref e);
-                            break;
-                        }
-                    case APPLYBLASTLAYER:
-                        {
-                            var temp = advancedMessage.objectValue as object[];
-                            var bl = (BlastLayer)temp[0];
-                            var storeUncorruptBackup = (bool)temp[1];
-                            var merge = (temp.Length > 2) && (bool)temp[2];
-                            void a()
-                            {
-                                bl.Apply(storeUncorruptBackup, true, merge);
-                            }
+                        GenerateBlastLayer(advancedMessage, ref e);
+                        break;
 
-                            SyncObjectSingleton.EmuThreadExecute(a, true);
-                            break;
-                        }
+                    case APPLYBLASTLAYER:
+                        ApplyBlastLayer(advancedMessage);
+                        break;
 
                     case REMOTE_PUSHRTCSPEC:
                         RTCV.NetCore.AllSpec.CorruptCoreSpec = new FullSpec((PartialSpec)advancedMessage.objectValue, !RtcCore.Attached);
@@ -564,6 +550,20 @@ namespace RTCV.CorruptCore
             {
                 e.setReturnValue(bl);
             }
+        }
+
+        private void ApplyBlastLayer(NetCoreAdvancedMessage advancedMessage)
+        {
+            var temp = advancedMessage.objectValue as object[];
+            var bl = (BlastLayer)temp[0];
+            var storeUncorruptBackup = (bool)temp[1];
+            var merge = (temp.Length > 2) && (bool)temp[2];
+            void a()
+            {
+                bl.Apply(storeUncorruptBackup, true, merge);
+            }
+
+            SyncObjectSingleton.EmuThreadExecute(a, true);
         }
 
         public void Kill()

--- a/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
+++ b/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
@@ -103,29 +103,9 @@ namespace RTCV.CorruptCore
                         break;
 
                     case REMOTE_EVENT_RESTRICTFEATURES:
-                        {
-                            if (!RTCV.NetCore.AllSpec.VanguardSpec?.Get<bool>(VSPEC.SUPPORTS_SAVESTATES) ?? true)
-                            {
-                                LocalNetCoreRouter.Route(NetcoreCommands.UI, NetcoreCommands.REMOTE_DISABLESAVESTATESUPPORT);
-                            }
+                        RestrictFeatures();
+                        break;
 
-                            if (!RTCV.NetCore.AllSpec.VanguardSpec?.Get<bool>(VSPEC.SUPPORTS_REALTIME) ?? true)
-                            {
-                                LocalNetCoreRouter.Route(NetcoreCommands.UI, NetcoreCommands.REMOTE_DISABLEREALTIMESUPPORT);
-                            }
-
-                            if (!RTCV.NetCore.AllSpec.VanguardSpec?.Get<bool>(VSPEC.SUPPORTS_KILLSWITCH) ?? true)
-                            {
-                                LocalNetCoreRouter.Route(NetcoreCommands.UI, NetcoreCommands.REMOTE_DISABLEKILLSWITCHSUPPORT);
-                            }
-
-                            if (!RTCV.NetCore.AllSpec.VanguardSpec?.Get<bool>(VSPEC.SUPPORTS_GAMEPROTECTION) ?? true)
-                            {
-                                LocalNetCoreRouter.Route(NetcoreCommands.UI, NetcoreCommands.REMOTE_DISABLEGAMEPROTECTIONSUPPORT);
-                            }
-
-                            break;
-                        }
                     case REMOTE_EVENT_SHUTDOWN:
                         {
                             RtcCore.Shutdown();
@@ -496,6 +476,29 @@ namespace RTCV.CorruptCore
                 }
 
                 return e.returnMessage;
+            }
+        }
+
+        private static void RestrictFeatures()
+        {
+            if (!RTCV.NetCore.AllSpec.VanguardSpec?.Get<bool>(VSPEC.SUPPORTS_SAVESTATES) ?? true)
+            {
+                LocalNetCoreRouter.Route(NetcoreCommands.UI, NetcoreCommands.REMOTE_DISABLESAVESTATESUPPORT);
+            }
+
+            if (!RTCV.NetCore.AllSpec.VanguardSpec?.Get<bool>(VSPEC.SUPPORTS_REALTIME) ?? true)
+            {
+                LocalNetCoreRouter.Route(NetcoreCommands.UI, NetcoreCommands.REMOTE_DISABLEREALTIMESUPPORT);
+            }
+
+            if (!RTCV.NetCore.AllSpec.VanguardSpec?.Get<bool>(VSPEC.SUPPORTS_KILLSWITCH) ?? true)
+            {
+                LocalNetCoreRouter.Route(NetcoreCommands.UI, NetcoreCommands.REMOTE_DISABLEKILLSWITCHSUPPORT);
+            }
+
+            if (!RTCV.NetCore.AllSpec.VanguardSpec?.Get<bool>(VSPEC.SUPPORTS_GAMEPROTECTION) ?? true)
+            {
+                LocalNetCoreRouter.Route(NetcoreCommands.UI, NetcoreCommands.REMOTE_DISABLEGAMEPROTECTIONSUPPORT);
             }
         }
 

--- a/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
+++ b/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
@@ -69,7 +69,7 @@ namespace RTCV.CorruptCore
 
                     //UI sent a copy of the CorruptCore spec
                     case REMOTE_PUSHCORRUPTCORESPEC:
-                        PushCorruptCoreSpec((PartialSpec)advancedMessage.objectValue);
+                        PushCorruptCoreSpec((PartialSpec)advancedMessage.objectValue, ref e);
                         break;
 
                     //UI sent an update of the CorruptCore spec
@@ -369,7 +369,7 @@ namespace RTCV.CorruptCore
             }
         }
 
-        private void PushCorruptCoreSpec(PartialSpec partialSpec)
+        private void PushCorruptCoreSpec(PartialSpec partialSpec, ref NetCoreEventArgs e)
         {
             SyncObjectSingleton.FormExecute(() =>
             {

--- a/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
+++ b/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
@@ -27,16 +27,7 @@ namespace RTCV.CorruptCore
                 switch (e.message.Type)
                 {
                     case "GETSPECDUMPS":
-                        var sb = new StringBuilder();
-                        sb.AppendLine("Spec Dump from CorruptCore");
-                        sb.AppendLine();
-                        sb.AppendLine("UISpec");
-                        RTCV.NetCore.AllSpec.UISpec?.GetDump().ForEach(x => sb.AppendLine(x));
-                        sb.AppendLine("CorruptCoreSpec");
-                        RTCV.NetCore.AllSpec.CorruptCoreSpec?.GetDump().ForEach(x => sb.AppendLine(x));
-                        sb.AppendLine("VanguardSpec");
-                        RTCV.NetCore.AllSpec.VanguardSpec?.GetDump().ForEach(x => sb.AppendLine(x));
-                        e.setReturnValue(sb.ToString());
+                        GetSpecDumps(ref e);
                         break;
                     //UI sent its spec
                     case REMOTE_PUSHUISPEC:
@@ -293,6 +284,20 @@ namespace RTCV.CorruptCore
 
                 return e.returnMessage;
             }
+        }
+
+        private static void GetSpecDumps(ref NetCoreEventArgs e)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("Spec Dump from CorruptCore");
+            sb.AppendLine();
+            sb.AppendLine("UISpec");
+            RTCV.NetCore.AllSpec.UISpec?.GetDump().ForEach(x => sb.AppendLine(x));
+            sb.AppendLine("CorruptCoreSpec");
+            RTCV.NetCore.AllSpec.CorruptCoreSpec?.GetDump().ForEach(x => sb.AppendLine(x));
+            sb.AppendLine("VanguardSpec");
+            RTCV.NetCore.AllSpec.VanguardSpec?.GetDump().ForEach(x => sb.AppendLine(x));
+            e.setReturnValue(sb.ToString());
         }
 
         private static void PushCorruptCoreSpec(PartialSpec partialSpec, ref NetCoreEventArgs e)

--- a/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
+++ b/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
@@ -249,25 +249,6 @@ namespace RTCV.CorruptCore
                             break;
                         }
 
-                    /*
-                    case STASHKEY:
-                        {
-                            var temp = advancedMessage.objectValue as object[];
-
-                            var sk = temp[0] as StashKey;
-                            var romFilename = temp[1] as String;
-                            var romData = temp[2] as Byte[];
-
-                            if (!File.Exists(CorruptCore.rtcDir + Path.DirectorySeparatorChar + "WORKING" + Path.DirectorySeparatorChar + "SKS" + Path.DirectorySeparatorChar + romFilename))
-                                File.WriteAllBytes(CorruptCore.rtcDir + Path.DirectorySeparatorChar + "WORKING" + Path.DirectorySeparatorChar + "SKS" + Path.DirectorySeparatorChar + romFilename, romData);
-
-                            sk.RomFilename = CorruptCore.rtcDir + Path.DirectorySeparatorChar + "WORKING" + Path.DirectorySeparatorChar + "SKS" + Path.DirectorySeparatorChar + CorruptCore_Extensions.getShortFilenameFromPath(romFilename);
-                            sk.DeployState();
-                            sk.Run();
-                        }
-                        break;
-                        */
-
                     case REMOTE_PUSHRTCSPEC:
                         RTCV.NetCore.AllSpec.CorruptCoreSpec = new FullSpec((PartialSpec)advancedMessage.objectValue, !RtcCore.Attached);
                         e.setReturnValue(true);


### PR DESCRIPTION
`OnMessageReceived` is a massive message handling function. I've broken up most of the individual actions taken by each of the switches with helper functions.