### PR TITLE
[Refactor] BlastUnitWorkingData is now its own file

### DIFF
--- a/Source/Libraries/CorruptCore/BlastUnit.cs
+++ b/Source/Libraries/CorruptCore/BlastUnit.cs
@@ -1017,27 +1017,4 @@ namespace RTCV.CorruptCore
             return brokenUnits;
         }
     }
-
-    /// <summary>
-    /// Working data for BlastUnits.
-    /// Not serialized
-    /// </summary>
-    [Ceras.MemberConfig(TargetMember.None)]
-    public class BlastUnitWorkingData
-    {
-        //We Calculate a LastFrame at the beginning of execute
-        [NonSerialized]
-        public int LastFrame = -1;
-        //We calculate ExecuteFrameQueued which is the ExecuteFrame + the currentframe that was calculated at the time of it entering the execution pool
-        [NonSerialized]
-        public int ExecuteFrameQueued = 0;
-
-        //We use ApplyValue so we don't need to keep re-calculating the tiled value every execute if we don't have to.
-        [NonSerialized]
-        public byte[] ApplyValue = null;
-
-        //The data that has been backed up. This is a list of bytes so if they start backing up at IMMEDIATE, they can have historical backups
-        [NonSerialized]
-        public Queue<byte[]> StoreData = new Queue<byte[]>();
-    }
 }

--- a/Source/Libraries/CorruptCore/BlastUnitWorkingData.cs
+++ b/Source/Libraries/CorruptCore/BlastUnitWorkingData.cs
@@ -1,0 +1,29 @@
+namespace RTCV.CorruptCore
+{
+    using System;
+    using System.Collections.Generic;
+    using Ceras;
+
+    /// <summary>
+    /// Working data for BlastUnits.
+    /// Not serialized
+    /// </summary>
+    [Ceras.MemberConfig(TargetMember.None)]
+    public class BlastUnitWorkingData
+    {
+        //We Calculate a LastFrame at the beginning of execute
+        [NonSerialized]
+        public int LastFrame = -1;
+        //We calculate ExecuteFrameQueued which is the ExecuteFrame + the currentframe that was calculated at the time of it entering the execution pool
+        [NonSerialized]
+        public int ExecuteFrameQueued = 0;
+
+        //We use ApplyValue so we don't need to keep re-calculating the tiled value every execute if we don't have to.
+        [NonSerialized]
+        public byte[] ApplyValue = null;
+
+        //The data that has been backed up. This is a list of bytes so if they start backing up at IMMEDIATE, they can have historical backups
+        [NonSerialized]
+        public Queue<byte[]> StoreData = new Queue<byte[]>();
+    }
+}

--- a/Source/Libraries/CorruptCore/CorruptCore.csproj
+++ b/Source/Libraries/CorruptCore/CorruptCore.csproj
@@ -122,6 +122,7 @@
     <Compile Include="BlastTarget.cs" />
     <Compile Include="BlastTools.cs" />
     <Compile Include="BlastUnit.cs" />
+    <Compile Include="BlastUnitWorkingData.cs" />
     <Compile Include="ComboBoxItem.cs" />
     <Compile Include="CorruptCore.cs" />
     <Compile Include="Diff.cs" />


### PR DESCRIPTION
Continuing to conform to the guideline of "one class definition per file".

Eventually, it would be nice to move all of the `Blast*.cs` files to their own folder and all of the `Blast*` classes to their own namespace. Changing CorruptCore in any substantial way, however, would likely have butterfly effects on the emulators.