### PR TITLE
[Refactor] Move color-related UI code from `UICore` to `Colors`

### DIFF
--- a/Source/Frontend/UI/Colors.cs
+++ b/Source/Frontend/UI/Colors.cs
@@ -1,0 +1,180 @@
+namespace RTCV.UI
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Drawing;
+    using System.Linq;
+    using System.Windows.Forms;
+    using RTCV.CorruptCore;
+
+    public static class Colors
+    {
+        //public static Color generalColor = Color.FromArgb(60, 45, 70);
+        public static Color GeneralColor = Color.LightSteelBlue;
+
+        public static Color Light1Color;
+        public static Color Light2Color;
+        public static Color NormalColor;
+        public static Color Dark1Color;
+        public static Color Dark2Color;
+        public static Color Dark3Color;
+        public static Color Dark4Color;
+
+        public static void SetRTCColor(Color color, Control ctr = null)
+        {
+            HashSet<Control> allControls = new HashSet<Control>();
+
+            if (ctr == null)
+            {
+                foreach (Form targetForm in UICore.AllColorizedSingletons())
+                {
+                    if (targetForm != null)
+                    {
+                        foreach (var c in targetForm.Controls.getControlsWithTag())
+                            allControls.Add(c);
+                        allControls.Add(targetForm);
+                    }
+                }
+
+                //Get the extraforms
+                foreach (UI_CanvasForm targetForm in UI_CanvasForm.extraForms)
+                {
+                    foreach (var c in targetForm.Controls.getControlsWithTag())
+                        allControls.Add(c);
+                    allControls.Add(targetForm);
+                }
+
+                //We have to manually add the mtform because it's not singleton, not an extraForm, and not owned by any specific form
+                //Todo - Refactor this so we don't need to add it separately
+                if (UICore.mtForm != null)
+                {
+                    foreach (var c in UICore.mtForm.Controls.getControlsWithTag())
+                        allControls.Add(c);
+                    allControls.Add(UICore.mtForm);
+                }
+            }
+            else if (ctr is Form || ctr is UserControl)
+            {
+                foreach (var c in ctr.Controls.getControlsWithTag())
+                    allControls.Add(c);
+                allControls.Add(ctr);
+            }
+            else if (ctr is Form)
+            {
+                allControls.Add(ctr);
+            }
+
+            float generalDarken = -0.50f;
+            float light1 = 0.10f;
+            float light2 = 0.45f;
+            float dark1 = -0.20f;
+            float dark2 = -0.35f;
+            float dark3 = -0.50f;
+            float dark4 = -0.85f;
+
+            color = color.ChangeColorBrightness(generalDarken);
+
+            Light1Color = color.ChangeColorBrightness(light1);
+            Light2Color = color.ChangeColorBrightness(light2);
+            NormalColor = color;
+            Dark1Color = color.ChangeColorBrightness(dark1);
+            Dark2Color = color.ChangeColorBrightness(dark2);
+            Dark3Color = color.ChangeColorBrightness(dark3);
+            Dark4Color = color.ChangeColorBrightness(dark4);
+
+            var tag2ColorDico = new Dictionary<string, Color>
+            {
+                { "color:light2", Light2Color },
+                { "color:light1", Light1Color },
+                { "color:normal", NormalColor },
+                { "color:dark1", Dark1Color },
+                { "color:dark2", Dark2Color },
+                { "color:dark3", Dark3Color },
+                { "color:dark4", Dark4Color }
+            };
+
+            foreach (var c in allControls)
+            {
+                var tag = c.Tag?.ToString().Split(' ');
+
+                if (tag == null || tag.Length == 0)
+                {
+                    continue;
+                }
+
+                //Snag the tag and look for the color.
+                var ctag = tag.FirstOrDefault(x => x.Contains("color:"));
+
+                //We didn't find a valid color
+                if (ctag == null || !tag2ColorDico.TryGetValue(ctag, out Color _color))
+                {
+                    continue;
+                }
+
+                if (c is Label l && l.BackColor != Color.FromArgb(30, 31, 32))
+                {
+                    c.ForeColor = _color;
+                }
+                else
+                {
+                    c.BackColor = _color;
+                }
+
+                if (c is Button btn)
+                {
+                    btn.FlatAppearance.BorderColor = _color;
+                }
+
+                if (c is DataGridView dgv)
+                {
+                    dgv.BackgroundColor = _color;
+                }
+
+                c.Invalidate();
+            }
+        }
+
+        public static void SelectRTCColor()
+        {
+            // Show the color dialog.
+            Color color;
+            ColorDialog cd = new ColorDialog();
+            DialogResult result = cd.ShowDialog();
+            // See if user pressed ok.
+            if (result == DialogResult.OK)
+            {
+                // Set form background to the selected color.
+                color = cd.Color;
+            }
+            else
+            {
+                return;
+            }
+
+            GeneralColor = color;
+            SetRTCColor(color);
+
+            SaveRTCColor(color);
+        }
+
+        public static void LoadRTCColor()
+        {
+            if (RTCV.NetCore.Params.IsParamSet("COLOR"))
+            {
+                string[] bytes = RTCV.NetCore.Params.ReadParam("COLOR").Split(',');
+                GeneralColor = Color.FromArgb(Convert.ToByte(bytes[0]), Convert.ToByte(bytes[1]), Convert.ToByte(bytes[2]));
+            }
+            else
+            {
+                GeneralColor = Color.FromArgb(110, 150, 193);
+            }
+
+            SetRTCColor(GeneralColor);
+        }
+
+        public static void SaveRTCColor(Color color)
+        {
+            RTCV.NetCore.Params.SetParam("COLOR", color.R.ToString() + "," + color.G.ToString() + "," + color.B.ToString());
+        }
+    }
+}

--- a/Source/Frontend/UI/Components/Blast Editor/RTC_ColumnSelector_Form.cs
+++ b/Source/Frontend/UI/Components/Blast Editor/RTC_ColumnSelector_Form.cs
@@ -13,7 +13,7 @@
         public ColumnSelector()
         {
             InitializeComponent();
-            UICore.SetRTCColor(UICore.GeneralColor, this);
+            Colors.SetRTCColor(Colors.GeneralColor, this);
             this.FormClosing += this.ColumnSelector_Closing;
         }
 

--- a/Source/Frontend/UI/Components/Blast Editor/RTC_SanitizeTool_Form.cs
+++ b/Source/Frontend/UI/Components/Blast Editor/RTC_SanitizeTool_Form.cs
@@ -72,7 +72,7 @@ namespace RTCV.UI
 
         private void RTC_NewBlastEditorForm_Load(object sender, EventArgs e)
         {
-            UICore.SetRTCColor(UICore.GeneralColor, this);
+            Colors.SetRTCColor(Colors.GeneralColor, this);
         }
 
         public void btnReroll_Click(object sender, EventArgs e)

--- a/Source/Frontend/UI/Components/Containers/RTC_SelectBox_Form.cs
+++ b/Source/Frontend/UI/Components/Containers/RTC_SelectBox_Form.cs
@@ -15,7 +15,7 @@
         {
             InitializeComponent();
 
-            UICore.SetRTCColor(UICore.GeneralColor, this);
+            Colors.SetRTCColor(Colors.GeneralColor, this);
 
             childForms = _childForms;
 

--- a/Source/Frontend/UI/Components/Controls/OpenToolButton.cs
+++ b/Source/Frontend/UI/Components/Controls/OpenToolButton.cs
@@ -15,7 +15,7 @@ namespace RTCV.UI.Components.Controls
             {
                 onClickedAction.Invoke();
             };
-            UICore.SetRTCColor(UICore.GeneralColor, this);
+            Colors.SetRTCColor(Colors.GeneralColor, this);
         }
     }
 }

--- a/Source/Frontend/UI/Components/Settings/RTC_SettingsCorrupt_Form.cs
+++ b/Source/Frontend/UI/Components/Settings/RTC_SettingsCorrupt_Form.cs
@@ -15,7 +15,7 @@ namespace RTCV.UI
         {
             InitializeComponent();
 
-            UICore.SetRTCColor(UICore.GeneralColor, this);
+            Colors.SetRTCColor(Colors.GeneralColor, this);
 
             Load += RTC_SettingRerollForm_Load;
 

--- a/Source/Frontend/UI/Components/Settings/RTC_SettingsGeneral_Form.cs
+++ b/Source/Frontend/UI/Components/Settings/RTC_SettingsGeneral_Form.cs
@@ -66,7 +66,7 @@
 
         private void btnChangeRTCColor_Click(object sender, EventArgs e)
         {
-            UICore.SelectRTCColor();
+            Colors.SelectRTCColor();
         }
 
         private void cbDisableBizhawkOSD_CheckedChanged(object sender, EventArgs e)

--- a/Source/Frontend/UI/Components/Settings/RTC_SettingsHotkeyConfig_Form.cs
+++ b/Source/Frontend/UI/Components/Settings/RTC_SettingsHotkeyConfig_Form.cs
@@ -101,7 +101,7 @@ namespace RTCV.UI
 
         private void RTC_SettingsHotkeyConfig_Form_Load(object sender, EventArgs e)
         {
-            UICore.SetRTCColor(UICore.GeneralColor, this.Parent);
+            Colors.SetRTCColor(Colors.GeneralColor, this.Parent);
         }
 
         private void HotkeyHotkeyTabControlSelectedIndexChanged(object sender, EventArgs e)

--- a/Source/Frontend/UI/Forms/RTC_AnalyticsTool_Form.cs
+++ b/Source/Frontend/UI/Forms/RTC_AnalyticsTool_Form.cs
@@ -84,7 +84,7 @@
 
         private void RTC_AnalyticsToolForm_Load(object sender, EventArgs e)
         {
-            UICore.SetRTCColor(UICore.GeneralColor, this);
+            Colors.SetRTCColor(Colors.GeneralColor, this);
         }
 
         private void RTC_SanitizeTool_Form_FormClosing(object sender, FormClosingEventArgs e)

--- a/Source/Frontend/UI/Forms/RTC_BlastGenerator_Form.cs
+++ b/Source/Frontend/UI/Forms/RTC_BlastGenerator_Form.cs
@@ -81,7 +81,7 @@ namespace RTCV.UI
             dgvBlastGenerator.CellMouseClick += dgvBlastGenerator_CellMouseClick;
             dgvBlastGenerator.CellMouseDoubleClick += DgvBlastGenerator_CellMouseDoubleClick;
 
-            UICore.SetRTCColor(UICore.GeneralColor, this);
+            Colors.SetRTCColor(Colors.GeneralColor, this);
             getAllControls(this);
         }
 

--- a/Source/Frontend/UI/Forms/RTC_Intro_Form.cs
+++ b/Source/Frontend/UI/Forms/RTC_Intro_Form.cs
@@ -26,7 +26,7 @@
 
         private void RTC_Intro_Form_Load(object sender, EventArgs e)
         {
-            UICore.SetRTCColor(UICore.GeneralColor, this);
+            Colors.SetRTCColor(Colors.GeneralColor, this);
         }
 
         private void RTC_Intro_Form_FormClosing(object sender, FormClosingEventArgs e)

--- a/Source/Frontend/UI/Forms/RTC_NewBlastEditor_Form.cs
+++ b/Source/Frontend/UI/Forms/RTC_NewBlastEditor_Form.cs
@@ -225,7 +225,7 @@ namespace RTCV.UI
 
         private void RTC_NewBlastEditorForm_Load(object sender, EventArgs e)
         {
-            UICore.SetRTCColor(UICore.GeneralColor, this);
+            Colors.SetRTCColor(Colors.GeneralColor, this);
             _domains = MemoryDomains.MemoryInterfaces?.Keys?.Concat(MemoryDomains.VmdPool.Values.Select(it => it.ToString())).ToArray();
 
             dgvBlastEditor.AllowUserToOrderColumns = true;

--- a/Source/Frontend/UI/Modular/UI_CanvasForm.cs
+++ b/Source/Frontend/UI/Modular/UI_CanvasForm.cs
@@ -36,7 +36,7 @@
         {
             InitializeComponent();
 
-            UICore.SetRTCColor(UICore.GeneralColor, this);
+            Colors.SetRTCColor(Colors.GeneralColor, this);
 
             if (!extraForm)
             {

--- a/Source/Frontend/UI/Modular/UI_ComponentFormSubForm.cs
+++ b/Source/Frontend/UI/Modular/UI_ComponentFormSubForm.cs
@@ -9,7 +9,7 @@
         {
             InitializeComponent();
 
-            UICore.SetRTCColor(UICore.GeneralColor, this);
+            Colors.SetRTCColor(Colors.GeneralColor, this);
         }
 
         public bool SubForm_HasLeftButton => true;

--- a/Source/Frontend/UI/Modular/UI_ComponentFormTile.cs
+++ b/Source/Frontend/UI/Modular/UI_ComponentFormTile.cs
@@ -14,7 +14,7 @@
         public UI_ComponentFormTile()
         {
             InitializeComponent();
-            UICore.SetRTCColor(UICore.GeneralColor, this);
+            Colors.SetRTCColor(Colors.GeneralColor, this);
         }
 
         public void SetCompoentForm(Form _childForm, int _sizeX, int _sizeY, bool DisplayHeader)

--- a/Source/Frontend/UI/Modular/UI_CoreForm.cs
+++ b/Source/Frontend/UI/Modular/UI_CoreForm.cs
@@ -76,7 +76,7 @@ namespace RTCV.UI
             corePadding = pnSideBar.Width;
             xPadding = (Width - cfForm.Width) - corePadding;
 
-            //UICore.SetRTCColor(UICore.GeneralColor);
+            //Colors.SetRTCColor(Colors.GeneralColor);
         }
 
         private void UI_CoreForm_FormClosing(object sender, FormClosingEventArgs e)
@@ -243,7 +243,7 @@ This message only appears once.";
                 {
                     Size = pnSideBar.Size,
                     Location = new Point(0, 0),
-                    BackColor = UICore.Dark4Color,
+                    BackColor = Colors.Dark4Color,
                     Visible = false,
                 };
                 pnSideBar.Controls.Add(pnLockSidebar);
@@ -256,7 +256,7 @@ This message only appears once.";
             PrepareLockSideBar();
 
             Bitmap bmp = pnSideBar.getFormScreenShot();
-            bmp.Tint(Color.FromArgb(0xF0, UICore.Dark4Color));
+            bmp.Tint(Color.FromArgb(0xF0, Colors.Dark4Color));
             pnLockSidebar.BackgroundImage = bmp;
             pnLockSidebar.Visible = true;
         }

--- a/Source/Frontend/UI/Modular/UI_ShadowPanel.cs
+++ b/Source/Frontend/UI/Modular/UI_ShadowPanel.cs
@@ -25,7 +25,7 @@
                 Opacity = 0.2f
             };
 
-            UICore.SetRTCColor(UICore.GeneralColor, this);
+            Colors.SetRTCColor(Colors.GeneralColor, this);
 
             parentForm = _parentForm;
             UpdateBackground();
@@ -101,7 +101,7 @@
             }
 
             Bitmap bmp = parentForm.getFormScreenShot();
-            bmp.Tint(Color.FromArgb(0x7F, UICore.Dark4Color));
+            bmp.Tint(Color.FromArgb(0x7F, Colors.Dark4Color));
 
             this.Size = parentForm.Size;
             this.BackgroundImage = bmp;

--- a/Source/Frontend/UI/UI.csproj
+++ b/Source/Frontend/UI/UI.csproj
@@ -427,6 +427,7 @@
     <Compile Include="Modular\UI_ShadowPanel.Designer.cs">
       <DependentUpon>UI_ShadowPanel.cs</DependentUpon>
     </Compile>
+    <Compile Include="Colors.cs" />
     <Compile Include="UICore.cs" />
     <Compile Include="UIConnector.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Source/Frontend/UI/UICore.cs
+++ b/Source/Frontend/UI/UICore.cs
@@ -316,7 +316,6 @@ namespace RTCV.UI
         }
 
         public static volatile bool isClosing = false;
-        private static bool focus;
 
         public static void CloseAllRtcForms() //This allows every form to get closed to prevent RTC from hanging
         {

--- a/Source/Frontend/UI/UICore.cs
+++ b/Source/Frontend/UI/UICore.cs
@@ -348,12 +348,12 @@ namespace RTCV.UI
             Environment.Exit(0);
         }
 
-        public static Color Light1Color;
-        public static Color Light2Color;
-        public static Color NormalColor;
-        public static Color Dark1Color;
-        public static Color Dark2Color;
-        public static Color Dark3Color;
+        private static Color Light1Color;
+        private static Color Light2Color;
+        private static Color NormalColor;
+        private static Color Dark1Color;
+        private static Color Dark2Color;
+        private static Color Dark3Color;
         public static Color Dark4Color;
         private static bool interfaceLocked;
         private static bool lockPending;

--- a/Source/Frontend/UI/UICore.cs
+++ b/Source/Frontend/UI/UICore.cs
@@ -179,29 +179,6 @@ namespace RTCV.UI
             }
         }
 
-        private static bool isAnyRTCFormFocused()
-        {
-            bool ExternalForm = Form.ActiveForm == null;
-
-            if (ExternalForm)
-            {
-                return false;
-            }
-
-            var form = Form.ActiveForm;
-            var t = form.GetType();
-
-            focus = (
-                typeof(IAutoColorize).IsAssignableFrom(t) ||
-                typeof(CloudDebug).IsAssignableFrom(t) ||
-                typeof(DebugInfo_Form).IsAssignableFrom(t)
-            );
-
-            bool isAllowedForm = focus;
-
-            return isAllowedForm;
-        }
-
         public static void LockInterface(bool focusCoreForm = true, bool blockMainForm = false)
         {
             if (interfaceLocked || lockPending)

--- a/Source/Frontend/UI/UICore.cs
+++ b/Source/Frontend/UI/UICore.cs
@@ -30,10 +30,8 @@ namespace RTCV.UI
         private static System.Timers.Timer inputCheckTimer;
 
         //RTC Main Forms
-        //public static Color generalColor = Color.FromArgb(60, 45, 70);
-        public static Color GeneralColor = Color.LightSteelBlue;
-
         public static RTC_SelectBox_Form mtForm = null;
+
         public static BindingCollection HotkeyBindings = new BindingCollection();
 
         public static void Start(Form standaloneForm = null)
@@ -89,10 +87,10 @@ namespace RTCV.UI
                 UI_DefaultGrids.connectionStatus.LoadToMain();
             }
 
-            LoadRTCColor();
+            Colors.LoadRTCColor();
             S.GET<UI_CoreForm>().Show();
             Initialized.Set();
-            LoadRTCColor();
+            Colors.LoadRTCColor();
         }
 
         private static void FormRegister_FormRegistered(object sender, FormRegisteredEventArgs e)
@@ -273,7 +271,7 @@ namespace RTCV.UI
                 ib.blockPanel.BringToFront();
 
                 var bmp = c.getFormScreenShot();
-                bmp.Tint(Color.FromArgb(0xCC, UICore.Dark4Color));
+                bmp.Tint(Color.FromArgb(0xCC, Colors.Dark4Color));
 
                 ib.blockPanel.BackgroundImage = bmp;
             }
@@ -348,174 +346,9 @@ namespace RTCV.UI
             Environment.Exit(0);
         }
 
-        private static Color Light1Color;
-        private static Color Light2Color;
-        private static Color NormalColor;
-        private static Color Dark1Color;
-        private static Color Dark2Color;
-        private static Color Dark3Color;
-        public static Color Dark4Color;
         private static bool interfaceLocked;
         private static bool lockPending;
         private static object lockObject = new object();
-
-
-        public static void SetRTCColor(Color color, Control ctr = null)
-        {
-            HashSet<Control> allControls = new HashSet<Control>();
-
-            if (ctr == null)
-            {
-                foreach (Form targetForm in UICore.AllColorizedSingletons())
-                {
-                    if (targetForm != null)
-                    {
-                        foreach (var c in targetForm.Controls.getControlsWithTag())
-                            allControls.Add(c);
-                        allControls.Add(targetForm);
-                    }
-                }
-
-                //Get the extraforms
-                foreach (UI_CanvasForm targetForm in UI_CanvasForm.extraForms)
-                {
-                    foreach (var c in targetForm.Controls.getControlsWithTag())
-                        allControls.Add(c);
-                    allControls.Add(targetForm);
-                }
-
-                //We have to manually add the etform because it's not singleton, not an extraForm, and not owned by any specific form
-                //Todo - Refactor this so we don't need to add it separately
-                if (mtForm != null)
-                {
-                    foreach (var c in mtForm.Controls.getControlsWithTag())
-                        allControls.Add(c);
-                    allControls.Add(mtForm);
-                }
-            }
-            else if (ctr is Form || ctr is UserControl)
-            {
-                foreach (var c in ctr.Controls.getControlsWithTag())
-                    allControls.Add(c);
-                allControls.Add(ctr);
-            }
-            else if (ctr is Form)
-            {
-                allControls.Add(ctr);
-            }
-
-            float generalDarken = -0.50f;
-            float light1 = 0.10f;
-            float light2 = 0.45f;
-            float dark1 = -0.20f;
-            float dark2 = -0.35f;
-            float dark3 = -0.50f;
-            float dark4 = -0.85f;
-
-            color = color.ChangeColorBrightness(generalDarken);
-
-            Light1Color = color.ChangeColorBrightness(light1);
-            Light2Color = color.ChangeColorBrightness(light2);
-            NormalColor = color;
-            Dark1Color = color.ChangeColorBrightness(dark1);
-            Dark2Color = color.ChangeColorBrightness(dark2);
-            Dark3Color = color.ChangeColorBrightness(dark3);
-            Dark4Color = color.ChangeColorBrightness(dark4);
-
-            var tag2ColorDico = new Dictionary<string, Color>
-            {
-                { "color:light2", Light2Color },
-                { "color:light1", Light1Color },
-                { "color:normal", NormalColor },
-                { "color:dark1", Dark1Color },
-                { "color:dark2", Dark2Color },
-                { "color:dark3", Dark3Color },
-                { "color:dark4", Dark4Color }
-            };
-
-            foreach (var c in allControls)
-            {
-                var tag = c.Tag?.ToString().Split(' ');
-
-                if (tag == null || tag.Length == 0)
-                {
-                    continue;
-                }
-
-                //Snag the tag and look for the color.
-                var ctag = tag.FirstOrDefault(x => x.Contains("color:"));
-
-                //We didn't find a valid color
-                if (ctag == null || !tag2ColorDico.TryGetValue(ctag, out Color _color))
-                {
-                    continue;
-                }
-
-                if (c is Label l && l.BackColor != Color.FromArgb(30, 31, 32))
-                {
-                    c.ForeColor = _color;
-                }
-                else
-                {
-                    c.BackColor = _color;
-                }
-
-                if (c is Button btn)
-                {
-                    btn.FlatAppearance.BorderColor = _color;
-                }
-
-                if (c is DataGridView dgv)
-                {
-                    dgv.BackgroundColor = _color;
-                }
-
-                c.Invalidate();
-            }
-        }
-
-        public static void SelectRTCColor()
-        {
-            // Show the color dialog.
-            Color color;
-            ColorDialog cd = new ColorDialog();
-            DialogResult result = cd.ShowDialog();
-            // See if user pressed ok.
-            if (result == DialogResult.OK)
-            {
-                // Set form background to the selected color.
-                color = cd.Color;
-            }
-            else
-            {
-                return;
-            }
-
-            GeneralColor = color;
-            SetRTCColor(color);
-
-            SaveRTCColor(color);
-        }
-
-        public static void LoadRTCColor()
-        {
-            if (RTCV.NetCore.Params.IsParamSet("COLOR"))
-            {
-                string[] bytes = RTCV.NetCore.Params.ReadParam("COLOR").Split(',');
-                UICore.GeneralColor = Color.FromArgb(Convert.ToByte(bytes[0]), Convert.ToByte(bytes[1]), Convert.ToByte(bytes[2]));
-            }
-            else
-            {
-                UICore.GeneralColor = Color.FromArgb(110, 150, 193);
-            }
-
-            UICore.SetRTCColor(UICore.GeneralColor);
-        }
-
-        public static void SaveRTCColor(Color color)
-        {
-            RTCV.NetCore.Params.SetParam("COLOR", color.R.ToString() + "," + color.G.ToString() + "," + color.B.ToString());
-        }
 
         public static object InputLock = new object();
         //Borrowed from Bizhawk. Thanks guys


### PR DESCRIPTION
`RTCV.UI.UICore` was doing a little bit too much heavy lifting. I created `RTCV.UI.Colors` to handle all of the color-related UI code.