### PR TITLE
[Refactor] Move JsonHelper to its own file

### DIFF
--- a/Source/Libraries/CorruptCore/CorruptCore.csproj
+++ b/Source/Libraries/CorruptCore/CorruptCore.csproj
@@ -101,6 +101,7 @@
     <Compile Include="EventWarlock\WarlockActions\WarlockActionEcho.cs" />
     <Compile Include="EventWarlock\WarlockConditions\FirstEqualsSecond.cs" />
     <Compile Include="IRenderer.cs" />
+    <Compile Include="JsonHelper.cs" />
     <Compile Include="Exceptions\StockpileSaveException.cs" />
     <Compile Include="Extensions\ByteArrayComparer.cs" />
     <Compile Include="Extensions\NullableByteArrayComparer.cs" />

--- a/Source/Libraries/CorruptCore/CorruptCore_Extensions.cs
+++ b/Source/Libraries/CorruptCore/CorruptCore_Extensions.cs
@@ -11,8 +11,6 @@ namespace RTCV.CorruptCore
     using System.Text;
     using System.Windows.Forms;
     using Ceras;
-    using Newtonsoft.Json;
-    using RTCV.NetCore.SafeJsonTypeSerialization;
 
     public static class CorruptCore_Extensions
     {
@@ -682,49 +680,6 @@ namespace RTCV.CorruptCore
                 sb.AppendLine(string.Join(CultureInfo.CurrentCulture.TextInfo.ListSeparator, cells.Select(cell => "\"" + cell.Value + "\"").ToArray()));
             }
             return sb.ToString();
-        }
-    }
-
-    public static class JsonHelper
-    {
-        public static void Serialize(object value, Stream s, Formatting f = Formatting.None, JsonKnownTypesBinder binder = null)
-        {
-            using (var writer = new StreamWriter(s))
-            using (var jsonWriter = new JsonTextWriter(writer))
-            {
-                var ser = new JsonSerializer
-                {
-                    Formatting = f,
-                    SerializationBinder = binder ?? new JsonKnownTypesBinder()
-                };
-                ser.Converters.Add(new Newtonsoft.Json.Converters.StringEnumConverter());
-                ser.Serialize(jsonWriter, value);
-                jsonWriter.Flush();
-            }
-        }
-
-        public static T Deserialize<T>(Stream s, JsonKnownTypesBinder binder = null)
-        {
-            using (var reader = new StreamReader(s))
-            using (var jsonReader = new JsonTextReader(reader))
-            {
-                var ser = new JsonSerializer()
-                {
-                    SerializationBinder = binder ?? new JsonKnownTypesBinder()
-                };
-                return ser.Deserialize<T>(jsonReader);
-            }
-        }
-
-        //Wrap JsonConvert so we can access this in vanguard implementations without importing json.net directly
-        public static string Serialize(object value)
-        {
-            return JsonConvert.SerializeObject(value);
-        }
-
-        public static T Deserialize<T>(string str)
-        {
-            return JsonConvert.DeserializeObject<T>(str);
         }
     }
 

--- a/Source/Libraries/CorruptCore/JsonHelper.cs
+++ b/Source/Libraries/CorruptCore/JsonHelper.cs
@@ -1,0 +1,49 @@
+namespace RTCV.CorruptCore
+{
+    using System.IO;
+    using Newtonsoft.Json;
+    using RTCV.NetCore.SafeJsonTypeSerialization;
+
+    public static class JsonHelper
+    {
+        public static void Serialize(object value, Stream s, Formatting f = Formatting.None, JsonKnownTypesBinder binder = null)
+        {
+            using (var writer = new StreamWriter(s))
+            using (var jsonWriter = new JsonTextWriter(writer))
+            {
+                var ser = new JsonSerializer
+                {
+                    Formatting = f,
+                    SerializationBinder = binder ?? new JsonKnownTypesBinder()
+                };
+                ser.Converters.Add(new Newtonsoft.Json.Converters.StringEnumConverter());
+                ser.Serialize(jsonWriter, value);
+                jsonWriter.Flush();
+            }
+        }
+
+        public static T Deserialize<T>(Stream s, JsonKnownTypesBinder binder = null)
+        {
+            using (var reader = new StreamReader(s))
+            using (var jsonReader = new JsonTextReader(reader))
+            {
+                var ser = new JsonSerializer()
+                {
+                    SerializationBinder = binder ?? new JsonKnownTypesBinder()
+                };
+                return ser.Deserialize<T>(jsonReader);
+            }
+        }
+
+        //Wrap JsonConvert so we can access this in vanguard implementations without importing json.net directly
+        public static string Serialize(object value)
+        {
+            return JsonConvert.SerializeObject(value);
+        }
+
+        public static T Deserialize<T>(string str)
+        {
+            return JsonConvert.DeserializeObject<T>(str);
+        }
+    }
+}


### PR DESCRIPTION
`CorruptCore_Extensions.cs` contains multiple class definitions.