### PR TITLE
[Cleanup] Remove unused member NetCoreConnector.guid

### DIFF
--- a/Source/Libraries/NetCore/Connector.cs
+++ b/Source/Libraries/NetCore/Connector.cs
@@ -8,7 +8,6 @@ namespace RTCV.NetCore
     {
         private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
         public NetCoreSpec spec = null;
-        public Guid guid = Guid.NewGuid();
         internal UDPLink udp = null;
         internal volatile TCPLink tcp = null;
         internal MessageHub hub = null;


### PR DESCRIPTION
Not used in `RTCV` or Bizhawk. CI will tell us if it's used anywhere else.