### PR TITLE
Add DependaBot to repository

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: nuget
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  target-branch: "506"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
     interval: weekly
   open-pull-requests-limit: 10
   target-branch: "506"
+  ignore:
+    - dependency-name: "System.Runtime.CompilerServices.Unsafe"


### PR DESCRIPTION
Check out the pull requests on my fork for an example of what this looks like https://github.com/scowalt/RTCV/pulls

Curious if this type of automated dependency tracking is something we want to implement