### PR TITLE
Fixed SelectedPluginEngine not being sent to emulator side after a crash

### DIFF
--- a/Source/Frontend/UI/Components/Engine Config/CorruptionEngineForm.cs
+++ b/Source/Frontend/UI/Components/Engine Config/CorruptionEngineForm.cs
@@ -221,7 +221,7 @@ namespace RTCV.UI
 
             previousPluginEngine = RtcCore.SelectedPluginEngine;
             if (previousPluginEngine != null)
-                previousPluginEngine.Control.Hide();
+                previousPluginEngine.Control?.Hide();
 
             switch (cbSelectedEngine.SelectedItem.ToString())
             {

--- a/Source/Libraries/CorruptCore/CorruptCore.cs
+++ b/Source/Libraries/CorruptCore/CorruptCore.cs
@@ -127,7 +127,11 @@ namespace RTCV.CorruptCore
             set => AllSpec.CorruptCoreSpec.Update(RTCSPEC.CORE_SELECTEDENGINE, value);
         }
 
-        public static ICorruptionEngine SelectedPluginEngine { get; set; } = null;
+        public static ICorruptionEngine SelectedPluginEngine
+        {
+            get => (ICorruptionEngine)AllSpec.CorruptCoreSpec[RTCSPEC.CORE_SELECTEDPLUGINENGINE];
+            set => AllSpec.CorruptCoreSpec.Update(RTCSPEC.CORE_SELECTEDPLUGINENGINE, value);
+        }
 
         public static int CurrentPrecision
         {

--- a/Source/Libraries/CorruptCore/Enums.cs
+++ b/Source/Libraries/CorruptCore/Enums.cs
@@ -146,6 +146,7 @@ namespace RTCV.CorruptCore
     {
         public static readonly string RTCDIR = nameof(RTCDIR);
         public static readonly string CORE_SELECTEDENGINE = nameof(CORE_SELECTEDENGINE);
+        public static readonly string CORE_SELECTEDPLUGINENGINE = nameof(CORE_SELECTEDPLUGINENGINE);
         public static readonly string CORE_ALLOWCROSSCORECORRUPTION = nameof(CORE_ALLOWCROSSCORECORRUPTION);
         public static readonly string CORE_CURRENTPRECISION = nameof(CORE_CURRENTPRECISION);
         public static readonly string CORE_CURRENTALIGNMENT = nameof(CORE_CURRENTALIGNMENT);


### PR DESCRIPTION
Fixed SelectedPluginEngine not being sent to emulator side after a crash. 
After a crash, the SelectedPluginEngine variable was not sent over to the emulator side, causing blasts to produce no units if a plugin engine was selected before the crash.