### PR TITLE
CanvasGrid: Update LoadToMain

### DIFF
--- a/Source/Frontend/UI/Modular/CanvasGrid.cs
+++ b/Source/Frontend/UI/Modular/CanvasGrid.cs
@@ -74,9 +74,11 @@ namespace RTCV.UI
             componentForm.Anchor = anchor;
         }
 
-        internal void LoadToMain(bool dontAnchor = false)
+        internal void LoadToMain(bool dontAnchor = false, bool setDefault = false)
         {
-            S.GET<CoreForm>().SetDefaultGrid(this);
+            if (setDefault)
+                S.GET<CoreForm>().SetDefaultGrid(this);
+
             if (Params.IsParamSet("GH_OPEN_MAIN"))
             {
                 // if this actually is the GH grid, it's ok, it's set to true at the end of CoreForm.OpenGlitchHarvester()
@@ -247,7 +249,7 @@ namespace RTCV.UI
                             var coreForm = S.GET<CoreForm>();
                             if (data == "Main")
                             {
-                                cuGrid.LoadToMain();
+                                cuGrid.LoadToMain(false, true);
                             }
                             else
                             {

--- a/Source/Frontend/UI/Modular/CanvasGrid.cs
+++ b/Source/Frontend/UI/Modular/CanvasGrid.cs
@@ -74,7 +74,7 @@ namespace RTCV.UI
             componentForm.Anchor = anchor;
         }
 
-        internal void LoadToMain(bool dontAnchor = false, bool setDefault = false)
+        internal void LoadToMain(bool dontAnchor = false, bool setDefault = true)
         {
             if (setDefault)
                 S.GET<CoreForm>().SetDefaultGrid(this);
@@ -249,11 +249,11 @@ namespace RTCV.UI
                             var coreForm = S.GET<CoreForm>();
                             if (data == "Main")
                             {
-                                cuGrid.LoadToMain(false, true);
+                                cuGrid.LoadToMain();
                             }
                             else
                             {
-                                coreForm.SetDefaultGrid(cuGrid, true);
+                                coreForm.SetDefaultGrid(cuGrid);
                                 cuGrid.LoadToNewWindow("External");
                             }
 

--- a/Source/Frontend/UI/Modular/CoreForm.cs
+++ b/Source/Frontend/UI/Modular/CoreForm.cs
@@ -335,13 +335,13 @@ This message only appears once.";
         {
             if (Params.IsParamSet("SIMPLE_MODE"))
             {
-                DefaultGrids.simpleMode.LoadToMain(false, true);
+                DefaultGrids.simpleMode.LoadToMain();
                 SimpleModeForm smForm = S.GET<SimpleModeForm>();
                 smForm.EnteringSimpleMode();
             }
             else
             {
-                DefaultGrids.engineConfig.LoadToMain(false, true);
+                DefaultGrids.engineConfig.LoadToMain();
             }
         }
 

--- a/Source/Frontend/UI/Modular/CoreForm.cs
+++ b/Source/Frontend/UI/Modular/CoreForm.cs
@@ -335,13 +335,13 @@ This message only appears once.";
         {
             if (Params.IsParamSet("SIMPLE_MODE"))
             {
-                DefaultGrids.simpleMode.LoadToMain();
+                DefaultGrids.simpleMode.LoadToMain(false, true);
                 SimpleModeForm smForm = S.GET<SimpleModeForm>();
                 smForm.EnteringSimpleMode();
             }
             else
             {
-                DefaultGrids.engineConfig.LoadToMain();
+                DefaultGrids.engineConfig.LoadToMain(false, true);
             }
         }
 

--- a/Source/Frontend/UI/UIConnector.cs
+++ b/Source/Frontend/UI/UIConnector.cs
@@ -57,7 +57,7 @@ namespace RTCV.UI
                         $"{(string)AllSpec.VanguardSpec?[VSPEC.NAME] ?? "Vanguard"} connection timed out";
 
                     UICore.LockInterface();
-                    DefaultGrids.connectionStatus.LoadToMain();
+                    DefaultGrids.connectionStatus.LoadToMain(false, false);
                 }
 
                 S.GET<VmdActForm>()


### PR DESCRIPTION
commit 47b1fc58048d8856994d089335fae1bf490049e7 causes every CanvasGrid to set themselves as the default grid, meaning ~it will not correctly reload the main form after a crash.~ the connection status form will stay shown as it was the last form to be loaded.

This commit adds an input argument to control which forms run the SetDefaultGrid method.