### PR TITLE
Live Swapping

### DIFF
--- a/Source/Frontend/UI/Components/Blast Editor/SanitizeToolForm.cs
+++ b/Source/Frontend/UI/Components/Blast Editor/SanitizeToolForm.cs
@@ -525,7 +525,7 @@ namespace RTCV.UI
         internal async Task LoadCorrupt()
         {
             internalSK.BlastLayer = new BlastLayer(shownHalf);
-            S.GET<GlitchHarvesterBlastForm>().IsCorruptionApplied = internalSK.Run();
+            S.GET<GlitchHarvesterBlastForm>().IsCorruptionApplied = await internalSK.Run();
 
             await Task.Delay(1);
         }
@@ -557,7 +557,7 @@ namespace RTCV.UI
 
         internal async Task Replay()
         {
-            S.GET<GlitchHarvesterBlastForm>().IsCorruptionApplied = internalSK.Run();
+            S.GET<GlitchHarvesterBlastForm>().IsCorruptionApplied = await internalSK.Run();
 
             await Task.Delay(1);
         }

--- a/Source/Frontend/UI/Components/Blast Editor/SanitizeToolForm.cs
+++ b/Source/Frontend/UI/Components/Blast Editor/SanitizeToolForm.cs
@@ -286,7 +286,8 @@ namespace RTCV.UI
                 SystemCore = oldSk.SystemCore,
                 GameName = oldSk.GameName,
                 SyncSettings = oldSk.SyncSettings,
-                StateLocation = oldSk.StateLocation
+                StateLocation = oldSk.StateLocation,
+                EmuVer = oldSk.EmuVer
             };
             newSk.BlastLayer = (BlastLayer)oldSk.BlastLayer.Clone();
             StockpileManagerUISide.StashHistory.Add(newSk);
@@ -323,7 +324,8 @@ namespace RTCV.UI
                 SystemCore = oldSk.SystemCore,
                 GameName = oldSk.GameName,
                 SyncSettings = oldSk.SyncSettings,
-                StateLocation = oldSk.StateLocation
+                StateLocation = oldSk.StateLocation,
+                EmuVer = oldSk.EmuVer
             };
             newSk.BlastLayer = (BlastLayer)oldSk.BlastLayer.Clone();
             StockpileManagerUISide.StashHistory.Add(newSk);
@@ -390,7 +392,8 @@ namespace RTCV.UI
                 SystemCore = originalStashkey.SystemCore,
                 GameName = originalStashkey.GameName,
                 SyncSettings = originalStashkey.SyncSettings,
-                StateLocation = originalStashkey.StateLocation
+                StateLocation = originalStashkey.StateLocation,
+                EmuVer = originalStashkey.EmuVer
             };
             internalSK.BlastLayer = blClone;
             OriginalLayer = blClone;

--- a/Source/Frontend/UI/Components/Controls/SavestateList.cs
+++ b/Source/Frontend/UI/Components/Controls/SavestateList.cs
@@ -255,7 +255,8 @@ namespace RTCV.UI.Components.Controls
                             SystemCore = psk.SystemCore,
                             GameName = psk.GameName,
                             SyncSettings = psk.SyncSettings,
-                            StateLocation = psk.StateLocation
+                            StateLocation = psk.StateLocation,
+                            EmuVer = psk.EmuVer
                         };
 
                         newStashkey.BlastLayer = new BlastLayer();

--- a/Source/Frontend/UI/Components/Controls/SavestateList.cs
+++ b/Source/Frontend/UI/Components/Controls/SavestateList.cs
@@ -8,6 +8,7 @@ namespace RTCV.UI.Components.Controls
     using System.Drawing.Design;
     using System.IO;
     using System.Linq;
+    using System.Threading.Tasks;
     using System.Windows.Forms;
     using CorruptCore;
     using NetCore;
@@ -269,7 +270,7 @@ namespace RTCV.UI.Components.Controls
                         StashKey sk = StockpileManagerUISide.SaveState();
                         RegisterStashKeyTo(holder, sk);
                     })
-                    .AddItem("Load this entry", (ob, ev) =>
+                    .AddItem("Load this entry", async (ob, ev) =>
                     {
                         var holder = (SavestateHolder)((Button)sender).Parent;
                         StashKey psk = holder.sk;
@@ -280,7 +281,7 @@ namespace RTCV.UI.Components.Controls
                                 return;
                             }
 
-                            StockpileManagerUISide.LoadState(psk);
+                            await StockpileManagerUISide.LoadState(psk);
                         }
                         else
                         {
@@ -405,7 +406,7 @@ namespace RTCV.UI.Components.Controls
             return true;
         }
 
-        public void LoadCurrentState()
+        public async Task LoadCurrentState()
         {
             StashKey psk = SelectedHolder?.sk;
             if (psk != null)
@@ -415,7 +416,7 @@ namespace RTCV.UI.Components.Controls
                     return;
                 }
 
-                StockpileManagerUISide.LoadState(psk);
+                await StockpileManagerUISide.LoadState(psk);
             }
             else
             {
@@ -525,7 +526,7 @@ namespace RTCV.UI.Components.Controls
             }
         }
 
-        internal void LoadPreviousSavestateNow()
+        internal async Task LoadPreviousSavestateNow()
         {
             var sk = SelectedHolder?.sk;
 
@@ -550,8 +551,7 @@ namespace RTCV.UI.Components.Controls
                 return;
             }
 
-
-            StockpileManagerUISide.LoadState(prevHolder.sk);
+            await StockpileManagerUISide.LoadState(prevHolder.sk);
             StockpileManagerUISide.CurrentStashkey = null;
             S.GET<GlitchHarvesterBlastForm>().IsCorruptionApplied = false;
             LocalNetCoreRouter.Route(NetCore.Endpoints.CorruptCore, NetCore.Commands.Remote.ClearBlastlayerCache, false);

--- a/Source/Frontend/UI/Components/Engine Config/GeneralParametersForm.cs
+++ b/Source/Frontend/UI/Components/Engine Config/GeneralParametersForm.cs
@@ -39,14 +39,22 @@ namespace RTCV.UI
             RtcCore.CreateInfiniteUnits = cbCreateInfiniteUnits.Checked;
         }
 
-        private void OnFormShown(object sender, EventArgs e)
+        public void UpdateMaxIntensity()
         {
             object paramValue = AllSpec.VanguardSpec[VSPEC.OVERRIDE_DEFAULTMAXINTENSITY];
 
             if (paramValue is int maxIntensity)
-            {
                 multiTB_Intensity.SetMaximum(maxIntensity, false);
-            }
+            else
+                multiTB_Intensity.SetMaximum(65535, false);
+
+            if (multiTB_Intensity.Value > multiTB_Intensity.Maximum)
+                multiTB_Intensity.Value = multiTB_Intensity.Maximum;
+        }
+
+        private void OnFormShown(object sender, EventArgs e)
+        {
+            UpdateMaxIntensity();
         }
     }
 }

--- a/Source/Frontend/UI/Components/Glitch Harvester/GlitchHarvesterBlastForm.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/GlitchHarvesterBlastForm.cs
@@ -42,15 +42,6 @@ namespace RTCV.UI
             }
         }
 
-        private double timeout = 10.0;
-        private double time_elapsed = 0.0;
-        private System.Timers.Timer swapTimeout = new System.Timers.Timer
-        {
-            AutoReset = false,
-            Interval = 100
-        };
-        private event ElapsedEventHandler timeoutHandler;
-
         public GlitchHarvesterBlastForm()
         {
             InitializeComponent();
@@ -127,31 +118,7 @@ namespace RTCV.UI
             e.Effect = DragDropEffects.Link;
         }
 
-        private void OnSwapTimeout(object source, ElapsedEventArgs e, bool killswitchWasEnabled)
-        {
-            time_elapsed += 0.1;
-            logger.Trace(time_elapsed);
-            if (time_elapsed >= timeout)
-            {
-                MessageBox.Show($"Savestate failed to load.");
 
-                this.ParentCanvas?.CloseSubForm();
-                logger.Trace("Unlocking Interface");
-                UICore.UnlockInterface();
-                logger.Trace("Load cancelled");
-
-                AutoKillSwitch.Enabled = killswitchWasEnabled;
-                UICore.isSwapping = false;
-                swapTimeout.Stop();
-                swapTimeout.Elapsed -= timeoutHandler;
-                return;
-            }
-            else
-            {
-                swapTimeout.Stop();
-                swapTimeout.Start();
-            }
-        }
 
         public void OneTimeExecute()
         {
@@ -161,91 +128,14 @@ namespace RTCV.UI
 
             bool killswitchWasEnabled = AutoKillSwitch.Enabled;
 
-            timeoutHandler ??= (sender, e) => OnSwapTimeout(sender, e, killswitchWasEnabled);
-            
             // If the stockpile entry is from a different emulator, close the current one and wait until the new one has connected
             if (StockpileManagerUISide.CurrentStashkey.EmuVer != new DirectoryInfo(RtcCore.EmuDir).Name)
             {
-                time_elapsed = 0.0;
-                swapTimeout.Elapsed += timeoutHandler;
-                swapTimeout.Start();
-
-                logger.Trace("different emulator found, switching");
-
-                AutoKillSwitch.Enabled = false;
-                UICore.isSwapping = true;
-                
-
-                logger.Trace("Blocking UI");
-                UICore.LockInterface(false, true);
-                logger.Trace("UI Blocked");
-
-                string oldEmuDir = CorruptCore.RtcCore.EmuDir;
-                var newEmuDir = Path.Combine(Path.Combine(new DirectoryInfo(RtcCore.RtcDir).Parent.Parent.FullName, StockpileManagerUISide.CurrentStashkey.EmuVer));
-                CorruptCore.RtcCore.EmuDir = newEmuDir;
-
-                // Load the save progress form
-                S.GET<SaveProgressForm>().Dock = DockStyle.Fill;
-                this.ParentCanvas?.OpenSubForm(S.GET<SaveProgressForm>());
-                RtcCore.OnProgressBarUpdate(null, new ProgressBarEventArgs($"Switching from " + new DirectoryInfo(oldEmuDir).Name +
-                                                " to " + StockpileManagerUISide.CurrentStashkey.EmuVer, 0));
-
-                LocalNetCoreRouter.Route(NetCore.Endpoints.Vanguard, NetCore.Commands.Remote.EventCloseEmulator);
-
-                UICore.finishedClosing = false;
-                while (!UICore.finishedClosing)
-                {
-                    Thread.Sleep(100);
-                    Application.DoEvents();
-                }
-
-                var info = new ProcessStartInfo()
-                {
-                    UseShellExecute = false,
-                    WorkingDirectory = newEmuDir,
-                    FileName = Path.Combine(newEmuDir, "RESTARTDETACHEDRTC.bat"),
-                };
-
-                if (!File.Exists(info.FileName))
-                {
-                    MessageBox.Show($"Couldn't find {info.FileName}! Killswitch will not work.");
-
-                    this.ParentCanvas?.CloseSubForm();
-                    logger.Trace("Unlocking Interface");
-                    UICore.UnlockInterface();
-                    logger.Trace("Load cancelled");
-
-                    AutoKillSwitch.Enabled = killswitchWasEnabled;
-                    UICore.isSwapping = false;
-
+                var args = new object[] { StockpileManagerUISide.CurrentStashkey.EmuVer, this };
+                if (!LocalNetCoreRouter.QueryRoute<bool>(Endpoints.UI, RTCV.NetCore.Commands.Remote.SwapImplementation, args))
                     return;
-                }
-
-                logger.Trace("Starting the new process");
-                RtcCore.OnProgressBarUpdate(null, new ProgressBarEventArgs($"Starting " + StockpileManagerUISide.CurrentStashkey.EmuVer, 50));
-
-                Process.Start(info);
-
-                while (VanguardImplementation.connector.netConn.status != NetworkStatus.CONNECTED)
-                {
-                    Thread.Sleep(100);
-                    Application.DoEvents();
-                }
-
-                UICore.finishedSwapping = false;
-                // Once AllSpecSent() is finished, we've successfully finished swapping to the new emulator
-                while (!UICore.finishedSwapping)
-                {
-                    Thread.Sleep(100);
-                    Application.DoEvents();
-                }
             }
 
-            RtcCore.OnProgressBarUpdate(null, new ProgressBarEventArgs($"Loading stockpile entry", 100));
-
-            swapTimeout.Stop();
-            swapTimeout.Start();
-            
             if (ghMode == GlitchHarvesterMode.CORRUPT)
             {
                 IsCorruptionApplied = StockpileManagerUISide.ApplyStashkey(StockpileManagerUISide.CurrentStashkey, loadBeforeOperation);
@@ -269,16 +159,11 @@ namespace RTCV.UI
                 Render.StopRender();
             }
 
-            swapTimeout.Stop();
-            swapTimeout.Elapsed -= timeoutHandler;
-
-            this.ParentCanvas?.CloseSubForm();
             logger.Trace("Unlocking Interface");
             UICore.UnlockInterface();
             logger.Trace("Load done");
 
             AutoKillSwitch.Enabled = killswitchWasEnabled;
-            UICore.isSwapping = false;
 
             logger.Trace("Exiting OneTimeExecute()");
         }

--- a/Source/Frontend/UI/Components/Glitch Harvester/GlitchHarvesterBlastForm.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/GlitchHarvesterBlastForm.cs
@@ -124,35 +124,78 @@ namespace RTCV.UI
             S.GET<CoreForm>().AutoCorrupt = false;
 
             bool killswitchWasEnabled = AutoKillSwitch.Enabled;
+
+            var timeout = 10.0;
+            var time_elapsed = 0.0;
+            var swapTimeout = new System.Timers.Timer
+            {
+                AutoReset = false,
+                Interval = 100
+            };
+
+            swapTimeout.Elapsed += (sender, eventArgs) =>
+            {
+                time_elapsed += 0.1;
+                logger.Trace(time_elapsed);
+                if (time_elapsed >= timeout)
+                {
+                    MessageBox.Show($"Savestate failed to load.");
+
+                    this.ParentCanvas?.CloseSubForm();
+                    logger.Trace("Unlocking Interface");
+                    UICore.UnlockInterface();
+                    logger.Trace("Load cancelled");
+
+                    AutoKillSwitch.Enabled = killswitchWasEnabled;
+                    UICore.isSwapping = false;
+                    swapTimeout.Stop();
+                    return;
+                }
+                else
+                {
+                    swapTimeout.Stop();
+                    swapTimeout.Start();
+                }
+            };
+            
             // If the stockpile entry is from a different emulator, close the current one and wait until the new one has connected
             if (StockpileManagerUISide.CurrentStashkey.EmuVer != new DirectoryInfo(RtcCore.EmuDir).Name)
             {
+
                 logger.Trace("different emulator found, switching");
 
                 AutoKillSwitch.Enabled = false;
                 UICore.isSwapping = true;
                 
+
                 logger.Trace("Blocking UI");
                 UICore.LockInterface(false, true);
                 logger.Trace("UI Blocked");
 
+                string oldEmuDir = CorruptCore.RtcCore.EmuDir;
+                var newEmuDir = Path.Combine(Path.Combine(new DirectoryInfo(RtcCore.RtcDir).Parent.Parent.FullName, StockpileManagerUISide.CurrentStashkey.EmuVer));
+                CorruptCore.RtcCore.EmuDir = newEmuDir;
+
+                // Load the save progress form
                 S.GET<SaveProgressForm>().Dock = DockStyle.Fill;
                 this.ParentCanvas?.OpenSubForm(S.GET<SaveProgressForm>());
-                RtcCore.OnProgressBarUpdate(this, new ProgressBarEventArgs($"Switching from " + new DirectoryInfo(RtcCore.EmuDir).Name + " to " + StockpileManagerUISide.CurrentStashkey.EmuVer, 0));
+                RtcCore.OnProgressBarUpdate(null, new ProgressBarEventArgs($"Switching from " + new DirectoryInfo(oldEmuDir).Name +
+                                                " to " + StockpileManagerUISide.CurrentStashkey.EmuVer, 0));
 
                 LocalNetCoreRouter.Route(NetCore.Endpoints.Vanguard, NetCore.Commands.Remote.EventCloseEmulator);
-                VanguardImplementation.Shutdown();
 
-                //UICore.FirstConnect = true;
-                CorruptCore.RtcCore.EmuDir = Path.Combine(Path.Combine(new DirectoryInfo(RtcCore.RtcDir).Parent.Parent.FullName, StockpileManagerUISide.CurrentStashkey.EmuVer));
+                UICore.finishedClosing = false;
+                while (!UICore.finishedClosing)
+                {
+                    Thread.Sleep(100);
+                    Application.DoEvents();
+                }
 
-                logger.Trace("Starting the new process");
-                var oldEmuDir = CorruptCore.RtcCore.EmuDir;
                 var info = new ProcessStartInfo()
                 {
                     UseShellExecute = false,
-                    WorkingDirectory = oldEmuDir,
-                    FileName = Path.Combine(oldEmuDir, "RESTARTDETACHEDRTC.bat"),
+                    WorkingDirectory = newEmuDir,
+                    FileName = Path.Combine(newEmuDir, "RESTARTDETACHEDRTC.bat"),
                 };
 
                 if (!File.Exists(info.FileName))
@@ -170,30 +213,35 @@ namespace RTCV.UI
                     return;
                 }
 
+                logger.Trace("Starting the new process");
+                RtcCore.OnProgressBarUpdate(null, new ProgressBarEventArgs($"Starting " + StockpileManagerUISide.CurrentStashkey.EmuVer, 50));
+
                 Process.Start(info);
-                VanguardImplementation.StartServer();
-                var previous_status = VanguardImplementation.connector.netConn.status;
-                var reconnected = false;
-                while (!reconnected)
+
+                time_elapsed = 0.0;
+                swapTimeout.Start();
+
+                while (VanguardImplementation.connector.netConn.status != NetworkStatus.CONNECTED)
                 {
-                    if (previous_status != VanguardImplementation.connector.netConn.status)
-                    {
-                        if (VanguardImplementation.connector.netConn.status == NetworkStatus.CONNECTED)
-                        {
-                            reconnected = true;
-                        }
-                        else
-                        {
-                            previous_status = VanguardImplementation.connector.netConn.status;
-                        }
-                    }
-                    logger.Trace("sleeping");
-                    Thread.Sleep(250);
+                    Thread.Sleep(100);
+                    Application.DoEvents();
                 }
 
-                RtcCore.OnProgressBarUpdate(this, new ProgressBarEventArgs($"Loading stockpile entry", 50));
+                UICore.finishedSwapping = false;
+                // Once AllSpecSent() is finished, we've successfully finished swapping to the new emulator
+                while (!UICore.finishedSwapping)
+                {
+                    Thread.Sleep(100);
+                    Application.DoEvents();
+                }
             }
 
+            RtcCore.OnProgressBarUpdate(null, new ProgressBarEventArgs($"Loading stockpile entry", 100));
+
+            time_elapsed = 0.0;
+            swapTimeout.Stop();
+            swapTimeout.Start();
+            
             if (ghMode == GlitchHarvesterMode.CORRUPT)
             {
                 IsCorruptionApplied = StockpileManagerUISide.ApplyStashkey(StockpileManagerUISide.CurrentStashkey, loadBeforeOperation);
@@ -217,7 +265,8 @@ namespace RTCV.UI
                 Render.StopRender();
             }
 
-            RtcCore.OnProgressBarUpdate(this, new ProgressBarEventArgs($"Done", 100));
+            swapTimeout.Stop();
+
 
             this.ParentCanvas?.CloseSubForm();
             logger.Trace("Unlocking Interface");

--- a/Source/Frontend/UI/Components/Glitch Harvester/GlitchHarvesterBlastForm.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/GlitchHarvesterBlastForm.cs
@@ -120,7 +120,7 @@ namespace RTCV.UI
 
 
 
-        public void OneTimeExecute()
+        public async void OneTimeExecute()
         {
             logger.Trace("Entering OneTimeExecute()");
             //Disable autocorrupt
@@ -131,8 +131,7 @@ namespace RTCV.UI
             // If the stockpile entry is from a different emulator, close the current one and wait until the new one has connected
             if (StockpileManagerUISide.CurrentStashkey.EmuVer != new DirectoryInfo(RtcCore.EmuDir).Name)
             {
-                var args = new object[] { StockpileManagerUISide.CurrentStashkey.EmuVer, this };
-                if (!LocalNetCoreRouter.QueryRoute<bool>(Endpoints.UI, RTCV.NetCore.Commands.Remote.SwapImplementation, args))
+                if (!(await Task.Run(() => VanguardImplementation.SwapImplementation(StockpileManagerUISide.CurrentStashkey.EmuVer))))
                     return;
             }
 

--- a/Source/Frontend/UI/Components/Glitch Harvester/GlitchHarvesterBlastForm.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/GlitchHarvesterBlastForm.cs
@@ -11,6 +11,9 @@ namespace RTCV.UI
     using NetCore;
     using RTCV.Common;
     using Modular;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using RTCV.NetCore.Enums;
 
     public partial class GlitchHarvesterBlastForm : ComponentForm, IBlockable
     {
@@ -120,6 +123,63 @@ namespace RTCV.UI
             //Disable autocorrupt
             S.GET<CoreForm>().AutoCorrupt = false;
 
+            bool killswitchWasEnabled = AutoKillSwitch.Enabled;
+            // If the stockpile entry is from a different emulator, close the current one and wait until the new one has connected
+            if (StockpileManagerUISide.CurrentStashkey.EmuVer != new DirectoryInfo(RtcCore.EmuDir).Name)
+            {
+                logger.Trace("different emulator found, switching");
+
+                AutoKillSwitch.Enabled = false;
+                UICore.isSwapping = true;
+
+                logger.Trace("Blocking UI");
+                UICore.LockInterface(false, true);
+                logger.Trace("UI Blocked");
+
+                S.GET<SaveProgressForm>().Dock = DockStyle.Fill;
+                this.ParentCanvas?.OpenSubForm(S.GET<SaveProgressForm>());
+                RtcCore.OnProgressBarUpdate(this, new ProgressBarEventArgs($"Switching from " + new DirectoryInfo(RtcCore.EmuDir).Name + " to " + StockpileManagerUISide.CurrentStashkey.EmuVer, 0));
+
+                LocalNetCoreRouter.Route(NetCore.Endpoints.Vanguard, NetCore.Commands.Remote.EventCloseEmulator);
+                
+                UICore.FirstConnect = true;
+                CorruptCore.RtcCore.EmuDir = Path.Combine(Path.Combine(new DirectoryInfo(RtcCore.RtcDir).Parent.Parent.FullName, StockpileManagerUISide.CurrentStashkey.EmuVer));
+
+                logger.Trace("Starting the new process");
+                var info = new ProcessStartInfo();
+                var oldEmuDir = CorruptCore.RtcCore.EmuDir;
+                info.WorkingDirectory = oldEmuDir;
+                info.FileName = Path.Combine(oldEmuDir, "RESTARTDETACHEDRTC.bat");
+                if (!File.Exists(info.FileName))
+                {
+                    MessageBox.Show($"Couldn't find {info.FileName}! Killswitch will not work.");
+                    return;
+                }
+
+                Process.Start(info);
+                VanguardImplementation.RestartServer();
+                var previous_status = VanguardImplementation.connector.netConn.status;
+                var reconnected = false;
+                while (!reconnected)
+                {
+                    if (previous_status != VanguardImplementation.connector.netConn.status)
+                    {
+                        if (VanguardImplementation.connector.netConn.status == NetworkStatus.CONNECTED)
+                        {
+                            reconnected = true;
+                        }
+                        else
+                        {
+                            previous_status = VanguardImplementation.connector.netConn.status;
+                        }
+                    }
+                    logger.Trace("sleeping");
+                    Thread.Sleep(100);
+                }
+
+                RtcCore.OnProgressBarUpdate(this, new ProgressBarEventArgs($"Loading stockpile entry", 50));
+            }
+
             if (ghMode == GlitchHarvesterMode.CORRUPT)
             {
                 IsCorruptionApplied = StockpileManagerUISide.ApplyStashkey(StockpileManagerUISide.CurrentStashkey, loadBeforeOperation);
@@ -142,6 +202,17 @@ namespace RTCV.UI
             {
                 Render.StopRender();
             }
+
+            RtcCore.OnProgressBarUpdate(this, new ProgressBarEventArgs($"Done", 100));
+
+            this.ParentCanvas?.CloseSubForm();
+            logger.Trace("Unlocking Interface");
+            UICore.UnlockInterface();
+            logger.Trace("Load done");
+
+            AutoKillSwitch.Enabled = killswitchWasEnabled;
+            UICore.isSwapping = false;
+
             logger.Trace("Exiting OneTimeExecute()");
         }
 

--- a/Source/Frontend/UI/Components/Glitch Harvester/GlitchHarvesterBlastForm.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/GlitchHarvesterBlastForm.cs
@@ -99,7 +99,7 @@ namespace RTCV.UI
             this.updatingBackColor = false;
         }
 
-        private void OnDragDrop(object sender, DragEventArgs e)
+        private async void OnDragDrop(object sender, DragEventArgs e)
         {
             string[] files = (string[])e.Data.GetData(DataFormats.FileDrop, false);
             foreach (var f in files)
@@ -108,7 +108,7 @@ namespace RTCV.UI
                 {
                     BlastLayer bl = BlastTools.LoadBlastLayerFromFile(f);
                     var newStashKey = new StashKey(RtcCore.GetRandomKey(), null, bl);
-                    S.GET<GlitchHarvesterBlastForm>().IsCorruptionApplied = StockpileManagerUISide.ApplyStashkey(newStashKey, false, false);
+                    S.GET<GlitchHarvesterBlastForm>().IsCorruptionApplied = await StockpileManagerUISide.ApplyStashkey(newStashKey, false, false);
                 }
             }
         }
@@ -131,22 +131,22 @@ namespace RTCV.UI
             // If the stockpile entry is from a different emulator, close the current one and wait until the new one has connected
             if (StockpileManagerUISide.CurrentStashkey.EmuVer != new DirectoryInfo(RtcCore.EmuDir).Name)
             {
-                if (!(await Task.Run(() => VanguardImplementation.SwapImplementation(StockpileManagerUISide.CurrentStashkey.EmuVer))))
+                if (!(await VanguardImplementation.SwapImplementation(StockpileManagerUISide.CurrentStashkey.EmuVer)))
                     return;
             }
 
             if (ghMode == GlitchHarvesterMode.CORRUPT)
             {
-                IsCorruptionApplied = StockpileManagerUISide.ApplyStashkey(StockpileManagerUISide.CurrentStashkey, loadBeforeOperation);
+                IsCorruptionApplied = await StockpileManagerUISide.ApplyStashkey(StockpileManagerUISide.CurrentStashkey, loadBeforeOperation);
             }
             else if (ghMode == GlitchHarvesterMode.INJECT)
             {
-                IsCorruptionApplied = StockpileManagerUISide.InjectFromStashkey(StockpileManagerUISide.CurrentStashkey, loadBeforeOperation);
+                IsCorruptionApplied = await StockpileManagerUISide.InjectFromStashkey(StockpileManagerUISide.CurrentStashkey, loadBeforeOperation);
                 S.GET<StashHistoryForm>().RefreshStashHistory();
             }
             else if (ghMode == GlitchHarvesterMode.ORIGINAL)
             {
-                IsCorruptionApplied = StockpileManagerUISide.OriginalFromStashkey(StockpileManagerUISide.CurrentStashkey);
+                IsCorruptionApplied = await StockpileManagerUISide.OriginalFromStashkey(StockpileManagerUISide.CurrentStashkey);
             }
 
             if (Render.RenderAtLoad && loadBeforeOperation)
@@ -218,7 +218,7 @@ namespace RTCV.UI
             }
         }
 
-        public void Corrupt(object sender, EventArgs e)
+        public async void Corrupt(object sender, EventArgs e)
         {
             logger.Trace("btnCorrupt Clicked");
 
@@ -233,12 +233,6 @@ namespace RTCV.UI
             try
             {
                 SetBlastButtonVisibility(false);
-
-                if (!(AllSpec.UISpec[UISPEC.SELECTEDDOMAINS] is string[] domains) || domains.Length == 0)
-                {
-                    MessageBox.Show("Can't corrupt with no domains selected.");
-                    return;
-                }
 
                 //Shut off autocorrupt if it's on.
                 //Leave this check here so we don't wastefully update the spec
@@ -260,7 +254,7 @@ namespace RTCV.UI
                         sks.Add((StashKey)row.Cells[0].Value);
                     }
 
-                    IsCorruptionApplied = StockpileManagerUISide.MergeStashkeys(sks);
+                    IsCorruptionApplied = await StockpileManagerUISide.MergeStashkeys(sks);
 
                     S.GET<StashHistoryForm>().RefreshStashHistorySelectLast();
                     //lbStashHistory.TopIndex = lbStashHistory.Items.Count - 1;
@@ -279,7 +273,7 @@ namespace RTCV.UI
                     }
 
                     S.GET<StashHistoryForm>().DontLoadSelectedStash = true;
-                    IsCorruptionApplied = StockpileManagerUISide.Corrupt(loadBeforeOperation);
+                    IsCorruptionApplied = await StockpileManagerUISide.Corrupt(loadBeforeOperation);
                     S.GET<StashHistoryForm>().RefreshStashHistorySelectLast();
                 }
                 else if (ghMode == GlitchHarvesterMode.INJECT)
@@ -300,7 +294,7 @@ namespace RTCV.UI
 
                     S.GET<StashHistoryForm>().DontLoadSelectedStash = true;
 
-                    IsCorruptionApplied = StockpileManagerUISide.InjectFromStashkey(StockpileManagerUISide.CurrentStashkey, loadBeforeOperation);
+                    IsCorruptionApplied = await StockpileManagerUISide.InjectFromStashkey(StockpileManagerUISide.CurrentStashkey, loadBeforeOperation);
                     S.GET<StashHistoryForm>().RefreshStashHistorySelectLast();
                 }
                 else if (ghMode == GlitchHarvesterMode.ORIGINAL)
@@ -318,7 +312,7 @@ namespace RTCV.UI
                     }
 
                     S.GET<StashHistoryForm>().DontLoadSelectedStash = true;
-                    IsCorruptionApplied = StockpileManagerUISide.OriginalFromStashkey(StockpileManagerUISide.CurrentStashkey);
+                    IsCorruptionApplied = await StockpileManagerUISide.OriginalFromStashkey(StockpileManagerUISide.CurrentStashkey);
                 }
 
                 if (Render.RenderAtLoad && loadBeforeOperation)
@@ -352,9 +346,9 @@ namespace RTCV.UI
 
             new ContextMenuBuilder()
                 .AddItem("Blast + Send RAW To Stash", (ob, ev) => BlastRawStash())
-                .AddItem("Corrupt", (ob, ev) => CorruptWithMode(GlitchHarvesterMode.CORRUPT))
-                .AddItem("Inject", (ob, ev) => CorruptWithMode(GlitchHarvesterMode.INJECT))
-                .AddItem("Original", (ob, ev) => CorruptWithMode(GlitchHarvesterMode.ORIGINAL))
+                .AddItem("Corrupt", async (ob, ev) => await Task.Run(() => CorruptWithMode(GlitchHarvesterMode.CORRUPT)))
+                .AddItem("Inject", async (ob, ev) => await Task.Run(() => CorruptWithMode(GlitchHarvesterMode.INJECT)))
+                .AddItem("Original", async (ob, ev) => await Task.Run(() => CorruptWithMode(GlitchHarvesterMode.ORIGINAL)))
                 .Build()
                 .Show(this, locate);
             
@@ -450,7 +444,7 @@ namespace RTCV.UI
             }
         }
 
-        public void RerollSelected(object sender, EventArgs e)
+        public async void RerollSelected(object sender, EventArgs e)
         {
             if (!btnRerollSelected.Visible)
             {
@@ -498,7 +492,7 @@ namespace RTCV.UI
                             .lbStashHistory.Items.Count - 1;
                     }
 
-                    IsCorruptionApplied = StockpileManagerUISide.ApplyStashkey(StockpileManagerUISide.CurrentStashkey);
+                    IsCorruptionApplied = await StockpileManagerUISide.ApplyStashkey(StockpileManagerUISide.CurrentStashkey);
                 }
             }
             finally

--- a/Source/Frontend/UI/Components/Glitch Harvester/GlitchHarvesterBlastForm.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/GlitchHarvesterBlastForm.cs
@@ -131,7 +131,7 @@ namespace RTCV.UI
 
                 AutoKillSwitch.Enabled = false;
                 UICore.isSwapping = true;
-
+                
                 logger.Trace("Blocking UI");
                 UICore.LockInterface(false, true);
                 logger.Trace("UI Blocked");
@@ -141,23 +141,37 @@ namespace RTCV.UI
                 RtcCore.OnProgressBarUpdate(this, new ProgressBarEventArgs($"Switching from " + new DirectoryInfo(RtcCore.EmuDir).Name + " to " + StockpileManagerUISide.CurrentStashkey.EmuVer, 0));
 
                 LocalNetCoreRouter.Route(NetCore.Endpoints.Vanguard, NetCore.Commands.Remote.EventCloseEmulator);
-                
-                UICore.FirstConnect = true;
+                VanguardImplementation.Shutdown();
+
+                //UICore.FirstConnect = true;
                 CorruptCore.RtcCore.EmuDir = Path.Combine(Path.Combine(new DirectoryInfo(RtcCore.RtcDir).Parent.Parent.FullName, StockpileManagerUISide.CurrentStashkey.EmuVer));
 
                 logger.Trace("Starting the new process");
-                var info = new ProcessStartInfo();
                 var oldEmuDir = CorruptCore.RtcCore.EmuDir;
-                info.WorkingDirectory = oldEmuDir;
-                info.FileName = Path.Combine(oldEmuDir, "RESTARTDETACHEDRTC.bat");
+                var info = new ProcessStartInfo()
+                {
+                    UseShellExecute = false,
+                    WorkingDirectory = oldEmuDir,
+                    FileName = Path.Combine(oldEmuDir, "RESTARTDETACHEDRTC.bat"),
+                };
+
                 if (!File.Exists(info.FileName))
                 {
                     MessageBox.Show($"Couldn't find {info.FileName}! Killswitch will not work.");
+
+                    this.ParentCanvas?.CloseSubForm();
+                    logger.Trace("Unlocking Interface");
+                    UICore.UnlockInterface();
+                    logger.Trace("Load cancelled");
+
+                    AutoKillSwitch.Enabled = killswitchWasEnabled;
+                    UICore.isSwapping = false;
+
                     return;
                 }
 
                 Process.Start(info);
-                VanguardImplementation.RestartServer();
+                VanguardImplementation.StartServer();
                 var previous_status = VanguardImplementation.connector.netConn.status;
                 var reconnected = false;
                 while (!reconnected)
@@ -174,7 +188,7 @@ namespace RTCV.UI
                         }
                     }
                     logger.Trace("sleeping");
-                    Thread.Sleep(100);
+                    Thread.Sleep(250);
                 }
 
                 RtcCore.OnProgressBarUpdate(this, new ProgressBarEventArgs($"Loading stockpile entry", 50));

--- a/Source/Frontend/UI/Components/Glitch Harvester/GlitchHarvesterBlastForm.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/GlitchHarvesterBlastForm.cs
@@ -129,7 +129,7 @@ namespace RTCV.UI
             bool killswitchWasEnabled = AutoKillSwitch.Enabled;
 
             // If the stockpile entry is from a different emulator, close the current one and wait until the new one has connected
-            if (StockpileManagerUISide.CurrentStashkey.EmuVer != new DirectoryInfo(RtcCore.EmuDir).Name)
+            if (!String.Equals(StockpileManagerUISide.CurrentStashkey.EmuVer, new DirectoryInfo(RtcCore.EmuDir).Name, StringComparison.OrdinalIgnoreCase))
             {
                 if (!(await VanguardImplementation.SwapImplementation(StockpileManagerUISide.CurrentStashkey.EmuVer)))
                     return;

--- a/Source/Frontend/UI/Components/Glitch Harvester/GlitchHarvesterBlastForm.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/GlitchHarvesterBlastForm.cs
@@ -14,6 +14,7 @@ namespace RTCV.UI
     using System.Threading;
     using System.Threading.Tasks;
     using RTCV.NetCore.Enums;
+    using System.Timers;
 
     public partial class GlitchHarvesterBlastForm : ComponentForm, IBlockable
     {
@@ -40,6 +41,15 @@ namespace RTCV.UI
                 isCorruptionApplied = value;
             }
         }
+
+        private double timeout = 10.0;
+        private double time_elapsed = 0.0;
+        private System.Timers.Timer swapTimeout = new System.Timers.Timer
+        {
+            AutoReset = false,
+            Interval = 100
+        };
+        private event ElapsedEventHandler timeoutHandler;
 
         public GlitchHarvesterBlastForm()
         {
@@ -117,6 +127,32 @@ namespace RTCV.UI
             e.Effect = DragDropEffects.Link;
         }
 
+        private void OnSwapTimeout(object source, ElapsedEventArgs e, bool killswitchWasEnabled)
+        {
+            time_elapsed += 0.1;
+            logger.Trace(time_elapsed);
+            if (time_elapsed >= timeout)
+            {
+                MessageBox.Show($"Savestate failed to load.");
+
+                this.ParentCanvas?.CloseSubForm();
+                logger.Trace("Unlocking Interface");
+                UICore.UnlockInterface();
+                logger.Trace("Load cancelled");
+
+                AutoKillSwitch.Enabled = killswitchWasEnabled;
+                UICore.isSwapping = false;
+                swapTimeout.Stop();
+                swapTimeout.Elapsed -= timeoutHandler;
+                return;
+            }
+            else
+            {
+                swapTimeout.Stop();
+                swapTimeout.Start();
+            }
+        }
+
         public void OneTimeExecute()
         {
             logger.Trace("Entering OneTimeExecute()");
@@ -125,42 +161,14 @@ namespace RTCV.UI
 
             bool killswitchWasEnabled = AutoKillSwitch.Enabled;
 
-            var timeout = 10.0;
-            var time_elapsed = 0.0;
-            var swapTimeout = new System.Timers.Timer
-            {
-                AutoReset = false,
-                Interval = 100
-            };
-
-            swapTimeout.Elapsed += (sender, eventArgs) =>
-            {
-                time_elapsed += 0.1;
-                logger.Trace(time_elapsed);
-                if (time_elapsed >= timeout)
-                {
-                    MessageBox.Show($"Savestate failed to load.");
-
-                    this.ParentCanvas?.CloseSubForm();
-                    logger.Trace("Unlocking Interface");
-                    UICore.UnlockInterface();
-                    logger.Trace("Load cancelled");
-
-                    AutoKillSwitch.Enabled = killswitchWasEnabled;
-                    UICore.isSwapping = false;
-                    swapTimeout.Stop();
-                    return;
-                }
-                else
-                {
-                    swapTimeout.Stop();
-                    swapTimeout.Start();
-                }
-            };
+            timeoutHandler ??= (sender, e) => OnSwapTimeout(sender, e, killswitchWasEnabled);
             
             // If the stockpile entry is from a different emulator, close the current one and wait until the new one has connected
             if (StockpileManagerUISide.CurrentStashkey.EmuVer != new DirectoryInfo(RtcCore.EmuDir).Name)
             {
+                time_elapsed = 0.0;
+                swapTimeout.Elapsed += timeoutHandler;
+                swapTimeout.Start();
 
                 logger.Trace("different emulator found, switching");
 
@@ -218,9 +226,6 @@ namespace RTCV.UI
 
                 Process.Start(info);
 
-                time_elapsed = 0.0;
-                swapTimeout.Start();
-
                 while (VanguardImplementation.connector.netConn.status != NetworkStatus.CONNECTED)
                 {
                     Thread.Sleep(100);
@@ -238,7 +243,6 @@ namespace RTCV.UI
 
             RtcCore.OnProgressBarUpdate(null, new ProgressBarEventArgs($"Loading stockpile entry", 100));
 
-            time_elapsed = 0.0;
             swapTimeout.Stop();
             swapTimeout.Start();
             
@@ -266,7 +270,7 @@ namespace RTCV.UI
             }
 
             swapTimeout.Stop();
-
+            swapTimeout.Elapsed -= timeoutHandler;
 
             this.ParentCanvas?.CloseSubForm();
             logger.Trace("Unlocking Interface");

--- a/Source/Frontend/UI/Components/Glitch Harvester/GlitchHarvesterIntensityForm.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/GlitchHarvesterIntensityForm.cs
@@ -20,14 +20,22 @@ namespace RTCV.UI
             multiTB_Intensity.ValueChanged += (sender, args) => RtcCore.Intensity = multiTB_Intensity.Value;
         }
 
-        private void OnFormShown(object sender, EventArgs e)
+        public void UpdateMaxIntensity()
         {
             object paramValue = AllSpec.VanguardSpec[VSPEC.OVERRIDE_DEFAULTMAXINTENSITY];
 
-            if (paramValue != null && paramValue is int maxintensity)
-            {
-                multiTB_Intensity.SetMaximum(maxintensity, false);
-            }
+            if (paramValue is int maxIntensity)
+                multiTB_Intensity.SetMaximum(maxIntensity, false);
+            else
+                multiTB_Intensity.SetMaximum(65535, false);
+
+            if (multiTB_Intensity.Value > multiTB_Intensity.Maximum)
+                multiTB_Intensity.Value = multiTB_Intensity.Maximum;
+        }
+
+        private void OnFormShown(object sender, EventArgs e)
+        {
+            UpdateMaxIntensity();
         }
     }
 }

--- a/Source/Frontend/UI/Components/Glitch Harvester/SavestateManagerForm.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/SavestateManagerForm.cs
@@ -130,11 +130,13 @@ namespace RTCV.UI
             }
 
             var s = (string)AllSpec.VanguardSpec?[VSPEC.NAME] ?? "ERROR";
+            /*
             if (!string.IsNullOrEmpty(ssk.VanguardImplementation) && !ssk.VanguardImplementation.Equals(s, StringComparison.OrdinalIgnoreCase) && ssk.VanguardImplementation != "ERROR")
             {
                 MessageBox.Show($"The ssk you loaded is for a different Vanguard implementation.\nThe ssk reported {ssk.VanguardImplementation} but you're connected to {s}.\nThis is a fatal error. Aborting load.");
                 return;
             }
+            */
 
             if (import)
             {

--- a/Source/Frontend/UI/Components/Glitch Harvester/StashHistoryForm.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/StashHistoryForm.cs
@@ -129,9 +129,6 @@ namespace RTCV.UI
             if (Params.IsParamSet("RASTERIZE_VMD_UPON_STOCKPILING"))
                 sk.BlastLayer.RasterizeVMDs();
 
-            // Add the emulator directory name
-            sk.EmuVer = new DirectoryInfo((string)AllSpec.VanguardSpec[VSPEC.EMUDIR]).Name;
-
             DataGridViewRow dataRow = S.GET<StockpileManagerForm>().dgvStockpile.Rows[S.GET<StockpileManagerForm>().dgvStockpile.Rows.Add()];
             dataRow.Cells["Item"].Value = sk;
             dataRow.Cells["GameName"].Value = sk.GameName;

--- a/Source/Frontend/UI/Components/Glitch Harvester/StashHistoryForm.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/StashHistoryForm.cs
@@ -137,6 +137,7 @@ namespace RTCV.UI
             dataRow.Cells["GameName"].Value = sk.GameName;
             dataRow.Cells["SystemName"].Value = sk.SystemName;
             dataRow.Cells["SystemCore"].Value = sk.SystemCore;
+            dataRow.Cells["EmuVer"].Value = sk.EmuVer;
             
             S.GET<StockpileManagerForm>().RefreshNoteIcons();
 

--- a/Source/Frontend/UI/Components/Glitch Harvester/StashHistoryForm.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/StashHistoryForm.cs
@@ -75,6 +75,8 @@ namespace RTCV.UI
             StashKey sk = (StashKey)lbStashHistory.SelectedItem;
             StockpileManagerUISide.CurrentStashkey = sk;
 
+            // Disabled with the addition of cross-emulator stockpiles
+            /*
             //If we don't support mixed stockpiles
             if (!((bool?)AllSpec.VanguardSpec[VSPEC.SUPPORTS_MIXED_STOCKPILE] ?? false))
             {
@@ -89,6 +91,7 @@ namespace RTCV.UI
                     }
                 }
             }
+            */
 
             if (askForName)
             {

--- a/Source/Frontend/UI/Components/Glitch Harvester/StashHistoryForm.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/StashHistoryForm.cs
@@ -9,6 +9,7 @@ namespace RTCV.UI
     using RTCV.Common;
     using RTCV.UI.Modular;
     using System.IO;
+    using System.Threading.Tasks;
 
     public partial class StashHistoryForm : ComponentForm, IBlockable
     {
@@ -242,7 +243,7 @@ namespace RTCV.UI
                         S.GET<VmdPoolForm>().RefreshVMDs();
                     }, selectionExists)
                     .AddSeparator()
-                    .AddItem("Merge Selected Stashkeys", (ob, ev) =>
+                    .AddItem("Merge Selected Stashkeys", async (ob, ev) =>
                     {
                         List<StashKey> sks = new List<StashKey>();
                         foreach (StashKey sk in lbStashHistory.SelectedItems)
@@ -250,7 +251,7 @@ namespace RTCV.UI
                             sks.Add(sk);
                         }
 
-                        StockpileManagerUISide.MergeStashkeys(sks);
+                        await StockpileManagerUISide.MergeStashkeys(sks);
 
                         RefreshStashHistorySelectLast();
                     }, selectionExists && lbStashHistory.SelectedItems.Count > 1)

--- a/Source/Frontend/UI/Components/Glitch Harvester/StashHistoryForm.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/StashHistoryForm.cs
@@ -8,6 +8,7 @@ namespace RTCV.UI
     using RTCV.NetCore;
     using RTCV.Common;
     using RTCV.UI.Modular;
+    using System.IO;
 
     public partial class StashHistoryForm : ComponentForm, IBlockable
     {
@@ -68,6 +69,8 @@ namespace RTCV.UI
             string Name = "";
             string value = "";
 
+
+
             StashKey sk = (StashKey)lbStashHistory.SelectedItem;
             StockpileManagerUISide.CurrentStashkey = sk;
 
@@ -126,12 +129,15 @@ namespace RTCV.UI
             if (Params.IsParamSet("RASTERIZE_VMD_UPON_STOCKPILING"))
                 sk.BlastLayer.RasterizeVMDs();
 
+            // Add the emulator directory name
+            sk.EmuVer = new DirectoryInfo((string)AllSpec.VanguardSpec[VSPEC.EMUDIR]).Name;
+
             DataGridViewRow dataRow = S.GET<StockpileManagerForm>().dgvStockpile.Rows[S.GET<StockpileManagerForm>().dgvStockpile.Rows.Add()];
             dataRow.Cells["Item"].Value = sk;
             dataRow.Cells["GameName"].Value = sk.GameName;
             dataRow.Cells["SystemName"].Value = sk.SystemName;
             dataRow.Cells["SystemCore"].Value = sk.SystemCore;
-
+            
             S.GET<StockpileManagerForm>().RefreshNoteIcons();
 
             StockpileManagerUISide.StashHistory.Remove(sk);

--- a/Source/Frontend/UI/Components/Glitch Harvester/StockpileEmuVersionForm.Designer.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/StockpileEmuVersionForm.Designer.cs
@@ -1,0 +1,112 @@
+﻿namespace RTCV.UI
+{
+    partial class StockpileEmuVersionForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.label1 = new System.Windows.Forms.Label();
+            this.EmuVersionDropDown = new System.Windows.Forms.ComboBox();
+            this.button1 = new System.Windows.Forms.Button();
+            this.button2 = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 20.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label1.Location = new System.Drawing.Point(13, 9);
+            this.label1.MaximumSize = new System.Drawing.Size(800, 0);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(727, 93);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "RTC has detected some stockpile entries do not have an associated emulator system" +
+    " and version. Please select the system and version this stockpile was created in" +
+    ".\r\n";
+            this.label1.Click += new System.EventHandler(this.label1_Click);
+            // 
+            // EmuVersionDropDown
+            // 
+            this.EmuVersionDropDown.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.EmuVersionDropDown.Font = new System.Drawing.Font("Microsoft Sans Serif", 21.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.EmuVersionDropDown.FormattingEnabled = true;
+            this.EmuVersionDropDown.Location = new System.Drawing.Point(19, 149);
+            this.EmuVersionDropDown.MaxDropDownItems = 3;
+            this.EmuVersionDropDown.Name = "EmuVersionDropDown";
+            this.EmuVersionDropDown.Size = new System.Drawing.Size(769, 41);
+            this.EmuVersionDropDown.TabIndex = 1;
+            this.EmuVersionDropDown.SelectedIndexChanged += new System.EventHandler(this.comboBox1_SelectedIndexChanged);
+            // 
+            // button1
+            // 
+            this.button1.AutoSize = true;
+            this.button1.Font = new System.Drawing.Font("Microsoft Sans Serif", 21.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.button1.Location = new System.Drawing.Point(219, 255);
+            this.button1.Name = "button1";
+            this.button1.Size = new System.Drawing.Size(121, 43);
+            this.button1.TabIndex = 2;
+            this.button1.Text = "OK";
+            this.button1.UseVisualStyleBackColor = true;
+            this.button1.Click += new System.EventHandler(this.button1_Click);
+            // 
+            // button2
+            // 
+            this.button2.AutoSize = true;
+            this.button2.Font = new System.Drawing.Font("Microsoft Sans Serif", 21.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.button2.Location = new System.Drawing.Point(460, 255);
+            this.button2.Name = "button2";
+            this.button2.Size = new System.Drawing.Size(121, 43);
+            this.button2.TabIndex = 3;
+            this.button2.Text = "Cancel";
+            this.button2.UseVisualStyleBackColor = true;
+            this.button2.Click += new System.EventHandler(this.button2_Click);
+            // 
+            // StockpileEmuVersionForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(800, 310);
+            this.Controls.Add(this.button2);
+            this.Controls.Add(this.button1);
+            this.Controls.Add(this.EmuVersionDropDown);
+            this.Controls.Add(this.label1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
+            this.Name = "StockpileEmuVersionForm";
+            this.ShowIcon = false;
+            this.TopMost = true;
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.ComboBox EmuVersionDropDown;
+        private System.Windows.Forms.Button button1;
+        private System.Windows.Forms.Button button2;
+    }
+}

--- a/Source/Frontend/UI/Components/Glitch Harvester/StockpileEmuVersionForm.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/StockpileEmuVersionForm.cs
@@ -1,0 +1,66 @@
+﻿using RTCV.CorruptCore;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Security.Policy;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace RTCV.UI
+{
+    public partial class StockpileEmuVersionForm : Form
+    {
+        public string SelectedVersion;
+        public StockpileEmuVersionForm(bool detected = true)
+        {
+            InitializeComponent();
+
+            string detected_text = "RTC has detected this stockpile does not have an associated emulator system and version. Please select the system and version this stockpile was created in.";
+            string default_text = "Please select the system and version the selected stockpile items were created in.";
+
+
+            label1.Text = detected ? detected_text : default_text;
+
+            var directories = Directory.GetDirectories(new DirectoryInfo(RtcCore.RtcDir).Parent.Parent.FullName);
+            foreach(var dir in directories)
+            {
+                var dirName = new DirectoryInfo(dir).Name;
+                if (dirName != "Launcher" && dirName != "RTCV")
+                { 
+                    EmuVersionDropDown.Items.Add(dirName);
+                }
+            }
+        }
+
+        private void comboBox1_Click(object sender, EventArgs e)
+        {
+            EmuVersionDropDown.DroppedDown = true;
+        }
+
+        private void comboBox1_SelectedIndexChanged(object sender, EventArgs e)
+        {
+
+        }
+
+        private void button1_Click(object sender, EventArgs e)
+        {
+            SelectedVersion = (string)EmuVersionDropDown.SelectedItem;
+            this.Close();
+        }
+
+        private void button2_Click(object sender, EventArgs e)
+        {
+            this.Close();
+        }
+
+        private void label1_Click(object sender, EventArgs e)
+        {
+
+        }
+    }
+}

--- a/Source/Frontend/UI/Components/Glitch Harvester/StockpileEmuVersionForm.resx
+++ b/Source/Frontend/UI/Components/Glitch Harvester/StockpileEmuVersionForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Source/Frontend/UI/Components/Glitch Harvester/StockpileManagerForm.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/StockpileManagerForm.cs
@@ -427,6 +427,8 @@ namespace RTCV.UI
                 logger.Trace("Starting Load Task");
                 var r = await Task.Run(() => Stockpile.Load(filename));
                 logger.Trace("Load Task Done");
+
+                var updated_emu_ver = false;
                 if (r.Failed)
                 {
                     logger.Trace("Load Task Failed");
@@ -440,10 +442,40 @@ namespace RTCV.UI
                     //Update the current stockpile to this one
                     StockpileManagerUISide.SetCurrentStockpile(sks);
 
-                    logger.Trace("Populating DGV");
+
+                    foreach (StashKey t in sks.StashKeys)
+                    {
+                        // Update stashkey emulator version if it's empty
+                        if (t.EmuVer == null)
+                        {
+                            var form = new StockpileEmuVersionForm();
+
+                            // start/show the control
+                            form.ShowDialog();
+
+                            if (form.SelectedVersion != null)
+                            {
+                                foreach (StashKey u in sks.StashKeys)
+                                {
+                                    u.EmuVer = form.SelectedVersion;
+                                }
+                                UnsavedEdits = true;
+                                updated_emu_ver = true;
+                            }
+                            else
+                            {
+                                MessageBox.Show("Emulator system and version selection was cancelled, the stockpile will not be loaded.", "Operation cancelled", MessageBoxButtons.OK);
+                                return;
+                            }
+                        }
+                        break;
+                    }
+
+
+                        logger.Trace("Populating DGV");
                     foreach (StashKey key in sks.StashKeys)
                     {
-                        dgvStockpile?.Rows.Add(key, key.GameName, key.SystemName, key.SystemCore, key.Note);
+                        dgvStockpile?.Rows.Add(key, key.GameName, key.SystemName, key.SystemCore, key.EmuVer, key.Note);
                     }
 
                     btnSaveStockpile.Enabled = true;
@@ -459,7 +491,7 @@ namespace RTCV.UI
                 dgvStockpile.ClearSelection();
                 StockpileManagerUISide.StockpileChanged();
 
-                UnsavedEdits = false;
+                UnsavedEdits = updated_emu_ver ? true : false;
             }
             finally
             {
@@ -848,6 +880,7 @@ namespace RTCV.UI
             dgvStockpile.DragEnter += HandleDragEnter;
         }
 
+        internal ToolStripButton UpdateEmuVersionButton;
         private void HandleGlitchHarvesterSettingsMouseDown(object sender, MouseEventArgs e)
         {
             Point locate = e.GetMouseLocation(sender);
@@ -895,5 +928,28 @@ namespace RTCV.UI
                 .Build()
                 .Show(this, locate);
         }
+
+        private void UpdateEmuVersionButton_Click(object sender, EventArgs e)
+        {
+            logger.Trace("test");
+            var form = new StockpileEmuVersionForm(false);
+
+            // start/show the control
+            form.ShowDialog();
+
+            if (form.SelectedVersion != null)
+            {
+                List<StashKey> sks = new List<StashKey>();
+                foreach (DataGridViewRow row in dgvStockpile.SelectedRows)
+                {
+                    StashKey sk = ((StashKey)row.Cells[0].Value);
+                    sk.EmuVer = form.SelectedVersion;
+                    row.Cells[EmuVer.Index].Value = form.SelectedVersion;
+                }
+
+                UnsavedEdits = true;
+            }
+        }
+
     }
 }

--- a/Source/Frontend/UI/Components/Glitch Harvester/StockpileManagerForm.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/StockpileManagerForm.cs
@@ -923,6 +923,7 @@ namespace RTCV.UI
             bool gameNameVisible = columns["GameName"]!.Visible;
             bool systemNameVisible = columns["SystemName"]!.Visible;
             bool systemCoreVisible = columns["SystemCore"]!.Visible;
+            bool emuVerVisible = columns["EmuVer"]!.Visible;
             
             new ContextMenuBuilder()
                 .AddHeader("Stockpile Manager Settings")
@@ -957,6 +958,15 @@ namespace RTCV.UI
                 .AddItem("Show System Core", (ob, ev)
                     => columns["SystemCore"]!.Visible = !systemCoreVisible,
                     isChecked: systemCoreVisible)
+
+                .AddItem("Show Emulator Version", (ob, ev)
+                    => columns["EmuVer"]!.Visible = !emuVerVisible,
+                    isChecked: emuVerVisible)
+
+                .AddSeparator()
+
+                .AddItem("Update Emulator Version", (ob, ev)
+                    => UpdateEmuVersionButton_Click(ob, ev))
                 
                 .Build()
                 .Show(this, locate);

--- a/Source/Frontend/UI/Components/Glitch Harvester/StockpileManagerForm.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/StockpileManagerForm.cs
@@ -404,14 +404,14 @@ namespace RTCV.UI
             bool missingEmuVer = false;
             foreach (StashKey key in sks.StashKeys)
             {
-                if (key.EmuVer != null)
+                if (key.EmuVer != "")
                 {
                     string emulatorPath = Path.Combine(RtcCore.RtcDir, "..\\..\\", key.EmuVer);
                     if (!Directory.Exists(emulatorPath) && !missingEmulators.Contains(key.EmuVer))
                         missingEmulators.Add(key.EmuVer);
                 }
                 // Update stashkey emulator version if it's empty
-                else if (key.EmuVer == null)
+                else
                 {
                     missingEmuVer = true;
                 }

--- a/Source/Frontend/UI/Components/Glitch Harvester/StockpileManagerForm.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/StockpileManagerForm.cs
@@ -407,7 +407,7 @@ namespace RTCV.UI
                 if (key.EmuVer != null)
                 {
                     string emulatorPath = Path.Combine(RtcCore.RtcDir, "..\\..\\", key.EmuVer);
-                    if (!Directory.Exists(emulatorPath))
+                    if (!Directory.Exists(emulatorPath) && !missingEmulators.Contains(key.EmuVer))
                         missingEmulators.Add(key.EmuVer);
                 }
                 // Update stashkey emulator version if it's empty

--- a/Source/Frontend/UI/Components/Glitch Harvester/StockpileManagerForm.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/StockpileManagerForm.cs
@@ -51,7 +51,7 @@ namespace RTCV.UI
             btnSaveStockpileAs.BackColorChanged += (o, e) => UpdateSaveButtonColor(UnsavedEdits);
         }
 
-        public void HandleCellClick(object sender, DataGridViewCellEventArgs e)
+        public async void HandleCellClick(object sender, DataGridViewCellEventArgs e)
         {
             if (e == null || e.RowIndex == -1)
             {
@@ -123,7 +123,7 @@ namespace RTCV.UI
 
                     sks.Reverse();
 
-                    StockpileManagerUISide.MergeStashkeys(sks);
+                    await StockpileManagerUISide.MergeStashkeys(sks);
 
                     if (Render.RenderAtLoad && S.GET<GlitchHarvesterBlastForm>().loadBeforeOperation)
                     {
@@ -195,12 +195,12 @@ namespace RTCV.UI
                         }
                     }, rowCount == 1)
                     .AddSeparator()
-                    .AddItem("Manual Inject", (ob, ev) =>
+                    .AddItem("Manual Inject", async (ob, ev) =>
                     {
                         var sk = this.GetSelectedStashKey();
                         StashKey newSk = (StashKey)sk.Clone();
 
-                        bool isCorrupted = StockpileManagerUISide.ApplyStashkey(newSk, false, false);
+                        bool isCorrupted = await StockpileManagerUISide.ApplyStashkey(newSk, false, false);
 
                         if (StockpileManagerUISide.CurrentStashkey != null)
                             S.GET<GlitchHarvesterBlastForm>().IsCorruptionApplied = isCorrupted;
@@ -226,7 +226,7 @@ namespace RTCV.UI
                         MemoryDomains.GenerateVmdFromStashkey(sk);
                         S.GET<VmdPoolForm>().RefreshVMDs();
                     }, rowCount == 1)
-                    .AddItem("Merge Selected Stashkeys", (ob, ev) =>
+                    .AddItem("Merge Selected Stashkeys", async (ob, ev) =>
                     {
                         List<StashKey> sks = new List<StashKey>();
                         foreach (DataGridViewRow row in this.dgvStockpile.SelectedRows)
@@ -234,7 +234,7 @@ namespace RTCV.UI
                             sks.Add((StashKey)row.Cells[0].Value);
                         }
 
-                        StockpileManagerUISide.MergeStashkeys(sks);
+                        await StockpileManagerUISide.MergeStashkeys(sks);
                         S.GET<StashHistoryForm>().RefreshStashHistorySelectLast();
                     }, rowCount > 1)
                     .AddItem("Replace Associated ROM", (ob, ev) =>
@@ -854,7 +854,7 @@ namespace RTCV.UI
             }
         }
 
-        private void StockpileUp(object sender, EventArgs e)
+        private async void StockpileUp(object sender, EventArgs e)
         {
             if (dgvStockpile.SelectedRows.Count == 0)
             {
@@ -876,11 +876,11 @@ namespace RTCV.UI
 
             if (_loadEntryWhenSelectedWithArrows)
             {
-                HandleCellClick(dgvStockpile, new DataGridViewCellEventArgs(0, dgvStockpile.SelectedRows[0].Index));
+                await Task.Run(() => HandleCellClick(dgvStockpile, new DataGridViewCellEventArgs(0, dgvStockpile.SelectedRows[0].Index)));
             }
         }
 
-        private void StockpileDown(object sender, EventArgs e)
+        private async void StockpileDown(object sender, EventArgs e)
         {
             if (dgvStockpile.SelectedRows.Count == 0)
             {
@@ -902,7 +902,7 @@ namespace RTCV.UI
 
             if (_loadEntryWhenSelectedWithArrows)
             {
-                HandleCellClick(dgvStockpile, new DataGridViewCellEventArgs(0, dgvStockpile.SelectedRows[0].Index));
+                await Task.Run(() => HandleCellClick(dgvStockpile, new DataGridViewCellEventArgs(0, dgvStockpile.SelectedRows[0].Index)));
             }
         }
 

--- a/Source/Frontend/UI/Components/Glitch Harvester/StockpileManagerForm.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/StockpileManagerForm.cs
@@ -971,11 +971,9 @@ namespace RTCV.UI
 
             if (form.SelectedVersion != null)
             {
-                List<StashKey> sks = new List<StashKey>();
                 foreach (DataGridViewRow row in dgvStockpile.SelectedRows)
                 {
-                    StashKey sk = ((StashKey)row.Cells[0].Value);
-                    sk.EmuVer = form.SelectedVersion;
+                    ((StashKey)row.Cells[0].Value).EmuVer = form.SelectedVersion;
                     row.Cells[EmuVer.Index].Value = form.SelectedVersion;
                 }
 

--- a/Source/Frontend/UI/Components/Glitch Harvester/StockpileManagerForm.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/StockpileManagerForm.cs
@@ -396,6 +396,63 @@ namespace RTCV.UI
             }
         }
 
+        // Check if any emulators in the stockpile are not installed, and prompt the user
+        // to select an emu version if it's a legacy stockpile.
+        public bool CheckForEmulators(Stockpile sks)
+        {
+            List<string> missingEmulators = new List<string> { };
+            bool missingEmuVer = false;
+            foreach (StashKey key in sks.StashKeys)
+            {
+                if (key.EmuVer != null)
+                {
+                    string emulatorPath = Path.Combine(RtcCore.RtcDir, "..\\..\\", key.EmuVer);
+                    if (!Directory.Exists(emulatorPath))
+                        missingEmulators.Add(key.EmuVer);
+                }
+                // Update stashkey emulator version if it's empty
+                else if (key.EmuVer == null)
+                {
+                    missingEmuVer = true;
+                }
+            }
+
+            if (missingEmulators.Count > 0)
+            {
+                string missingEmulatorsString = "";
+                foreach (string emulator in missingEmulators)
+                {
+                    missingEmulatorsString += emulator + "\n";
+                }
+                string missingEmulatorsMessage = "You are missing the following emulators used in this stockpile: \n\n" +
+                                                  String.Join(Environment.NewLine, missingEmulatorsString + "\n" +
+                                                  "Please install these emulators and then load the stockpile again.");
+                MessageBox.Show(missingEmulatorsMessage, "Operation cancelled", MessageBoxButtons.OK);
+                return false;
+            }
+            else if (missingEmuVer)
+            {
+                var form = new StockpileEmuVersionForm();
+
+                // start/show the control
+                form.ShowDialog();
+
+                if (form.SelectedVersion != null)
+                {
+                    foreach (StashKey key in sks.StashKeys)
+                    {
+                        key.EmuVer = form.SelectedVersion;
+                    }
+                }
+                else
+                {
+                    MessageBox.Show("Emulator system and version selection was cancelled, the stockpile will not be loaded.", "Operation cancelled", MessageBoxButtons.OK);
+                    return false;
+                }
+            }
+            return true;
+        }
+
         public async void LoadStockpile(string filename)
         {
             logger.Trace("Entered LoadStockpile {0}", Thread.CurrentThread.ManagedThreadId);
@@ -428,7 +485,6 @@ namespace RTCV.UI
                 var r = await Task.Run(() => Stockpile.Load(filename));
                 logger.Trace("Load Task Done");
 
-                var updated_emu_ver = false;
                 if (r.Failed)
                 {
                     logger.Trace("Load Task Failed");
@@ -443,36 +499,10 @@ namespace RTCV.UI
                     StockpileManagerUISide.SetCurrentStockpile(sks);
 
 
-                    foreach (StashKey t in sks.StashKeys)
-                    {
-                        // Update stashkey emulator version if it's empty
-                        if (t.EmuVer == null)
-                        {
-                            var form = new StockpileEmuVersionForm();
+                    if (!CheckForEmulators(sks))
+                        return;
 
-                            // start/show the control
-                            form.ShowDialog();
-
-                            if (form.SelectedVersion != null)
-                            {
-                                foreach (StashKey u in sks.StashKeys)
-                                {
-                                    u.EmuVer = form.SelectedVersion;
-                                }
-                                UnsavedEdits = true;
-                                updated_emu_ver = true;
-                            }
-                            else
-                            {
-                                MessageBox.Show("Emulator system and version selection was cancelled, the stockpile will not be loaded.", "Operation cancelled", MessageBoxButtons.OK);
-                                return;
-                            }
-                        }
-                        break;
-                    }
-
-
-                        logger.Trace("Populating DGV");
+                    logger.Trace("Populating DGV");
                     foreach (StashKey key in sks.StashKeys)
                     {
                         dgvStockpile?.Rows.Add(key, key.GameName, key.SystemName, key.SystemCore, key.EmuVer, key.Note);
@@ -491,7 +521,7 @@ namespace RTCV.UI
                 dgvStockpile.ClearSelection();
                 StockpileManagerUISide.StockpileChanged();
 
-                UnsavedEdits = updated_emu_ver ? true : false;
+                UnsavedEdits = true;
             }
             finally
             {
@@ -524,9 +554,12 @@ namespace RTCV.UI
                     //Populate the dgv
                     RtcCore.OnProgressBarUpdate(sks, new ProgressBarEventArgs($"Populating UI", 95));
 
+                    if (!CheckForEmulators(sks))
+                        return;
+
                     foreach (StashKey key in sks.StashKeys)
                     {
-                        dgvStockpile?.Rows.Add(key, key.GameName, key.SystemName, key.SystemCore, key.Note);
+                        dgvStockpile?.Rows.Add(key, key.GameName, key.SystemName, key.SystemCore, key.EmuVer, key.Note);
                     }
 
                     UnsavedEdits = true;
@@ -931,7 +964,6 @@ namespace RTCV.UI
 
         private void UpdateEmuVersionButton_Click(object sender, EventArgs e)
         {
-            logger.Trace("test");
             var form = new StockpileEmuVersionForm(false);
 
             // start/show the control

--- a/Source/Frontend/UI/Components/Glitch Harvester/StockpileManagerForm.designer.cs
+++ b/Source/Frontend/UI/Components/Glitch Harvester/StockpileManagerForm.designer.cs
@@ -28,17 +28,12 @@
         /// </summary>
         private void InitializeComponent()
         {
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle5 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle7 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle8 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle6 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(StockpileManagerForm));
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
             this.dgvStockpile = new RTCV.UI.Components.DataGridViewDraggable();
-            this.Item = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.GameName = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.SystemName = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.SystemCore = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Note = new System.Windows.Forms.DataGridViewButtonColumn();
             this.btnRenameSelected = new System.Windows.Forms.Button();
             this.btnImportStockpile = new System.Windows.Forms.Button();
             this.btnStockpileMoveSelectedDown = new System.Windows.Forms.Button();
@@ -51,6 +46,12 @@
             this.btnStockpileUP = new System.Windows.Forms.Button();
             this.btnRemoveSelectedStockpile = new System.Windows.Forms.Button();
             this.btnGlitchHarvesterSettings = new System.Windows.Forms.Button();
+            this.Item = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.GameName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.SystemName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.SystemCore = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.EmuVer = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Note = new System.Windows.Forms.DataGridViewButtonColumn();
             ((System.ComponentModel.ISupportInitialize)(this.dgvStockpile)).BeginInit();
             this.SuspendLayout();
             // 
@@ -66,14 +67,14 @@
             this.dgvStockpile.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
             this.dgvStockpile.BackgroundColor = System.Drawing.Color.Gray;
             this.dgvStockpile.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            dataGridViewCellStyle5.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle5.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle5.Font = new System.Drawing.Font("Segoe UI Symbol", 8F);
-            dataGridViewCellStyle5.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle5.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle5.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle5.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dgvStockpile.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle5;
+            dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle1.Font = new System.Drawing.Font("Segoe UI Symbol", 8F);
+            dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dgvStockpile.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
             this.dgvStockpile.ColumnHeadersHeight = 21;
             this.dgvStockpile.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
             this.dgvStockpile.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
@@ -81,27 +82,28 @@
             this.GameName,
             this.SystemName,
             this.SystemCore,
+            this.EmuVer,
             this.Note});
-            dataGridViewCellStyle7.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle7.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle7.Font = new System.Drawing.Font("Segoe UI Symbol", 8F);
-            dataGridViewCellStyle7.ForeColor = System.Drawing.SystemColors.ControlText;
-            dataGridViewCellStyle7.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle7.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle7.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.dgvStockpile.DefaultCellStyle = dataGridViewCellStyle7;
+            dataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.Window;
+            dataGridViewCellStyle3.Font = new System.Drawing.Font("Segoe UI Symbol", 8F);
+            dataGridViewCellStyle3.ForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle3.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle3.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle3.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.dgvStockpile.DefaultCellStyle = dataGridViewCellStyle3;
             this.dgvStockpile.GridColor = System.Drawing.Color.Black;
             this.dgvStockpile.Location = new System.Drawing.Point(12, 47);
             this.dgvStockpile.Name = "dgvStockpile";
             this.dgvStockpile.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            dataGridViewCellStyle8.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle8.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle8.Font = new System.Drawing.Font("Segoe UI Symbol", 8F);
-            dataGridViewCellStyle8.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle8.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle8.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle8.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dgvStockpile.RowHeadersDefaultCellStyle = dataGridViewCellStyle8;
+            dataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle4.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle4.Font = new System.Drawing.Font("Segoe UI Symbol", 8F);
+            dataGridViewCellStyle4.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle4.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle4.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle4.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dgvStockpile.RowHeadersDefaultCellStyle = dataGridViewCellStyle4;
             this.dgvStockpile.RowHeadersVisible = false;
             this.dgvStockpile.RowTemplate.Height = 25;
             this.dgvStockpile.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
@@ -110,49 +112,6 @@
             this.dgvStockpile.Tag = "color:dark1";
             this.dgvStockpile.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.HandleCellClick);
             this.dgvStockpile.MouseDown += new System.Windows.Forms.MouseEventHandler(this.HandleStockpileMouseDown);
-            // 
-            // Item
-            // 
-            this.Item.FillWeight = 145F;
-            this.Item.HeaderText = "Item Name";
-            this.Item.Name = "Item";
-            this.Item.ReadOnly = true;
-            // 
-            // GameName
-            // 
-            this.GameName.FillWeight = 76.73162F;
-            this.GameName.HeaderText = "Game";
-            this.GameName.Name = "GameName";
-            this.GameName.ReadOnly = true;
-            // 
-            // SystemName
-            // 
-            this.SystemName.FillWeight = 60F;
-            this.SystemName.HeaderText = "System";
-            this.SystemName.Name = "SystemName";
-            this.SystemName.ReadOnly = true;
-            // 
-            // SystemCore
-            // 
-            this.SystemCore.FillWeight = 60F;
-            this.SystemCore.HeaderText = "Core";
-            this.SystemCore.Name = "SystemCore";
-            this.SystemCore.ReadOnly = true;
-            this.SystemCore.Visible = false;
-            // 
-            // Note
-            // 
-            dataGridViewCellStyle6.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
-            dataGridViewCellStyle6.Font = new System.Drawing.Font("Segoe UI Symbol", 14.25F);
-            dataGridViewCellStyle6.ForeColor = System.Drawing.Color.Black;
-            this.Note.DefaultCellStyle = dataGridViewCellStyle6;
-            this.Note.FillWeight = 23.01949F;
-            this.Note.HeaderText = "Note";
-            this.Note.MinimumWidth = 35;
-            this.Note.Name = "Note";
-            this.Note.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.Note.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.Note.Text = "";
             // 
             // btnRenameSelected
             // 
@@ -402,6 +361,55 @@
             this.btnGlitchHarvesterSettings.UseVisualStyleBackColor = false;
             this.btnGlitchHarvesterSettings.MouseDown += new System.Windows.Forms.MouseEventHandler(this.HandleGlitchHarvesterSettingsMouseDown);
             // 
+            // Item
+            // 
+            this.Item.FillWeight = 145F;
+            this.Item.HeaderText = "Item Name";
+            this.Item.Name = "Item";
+            this.Item.ReadOnly = true;
+            // 
+            // GameName
+            // 
+            this.GameName.FillWeight = 76.73162F;
+            this.GameName.HeaderText = "Game";
+            this.GameName.Name = "GameName";
+            this.GameName.ReadOnly = true;
+            // 
+            // SystemName
+            // 
+            this.SystemName.FillWeight = 60F;
+            this.SystemName.HeaderText = "System";
+            this.SystemName.Name = "SystemName";
+            this.SystemName.ReadOnly = true;
+            // 
+            // SystemCore
+            // 
+            this.SystemCore.FillWeight = 60F;
+            this.SystemCore.HeaderText = "Core";
+            this.SystemCore.Name = "SystemCore";
+            this.SystemCore.ReadOnly = true;
+            this.SystemCore.Visible = false;
+            // 
+            // EmuVer
+            // 
+            this.EmuVer.HeaderText = "Emu Version";
+            this.EmuVer.Name = "EmuVer";
+            this.EmuVer.Visible = false;
+            // 
+            // Note
+            // 
+            dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            dataGridViewCellStyle2.Font = new System.Drawing.Font("Segoe UI Symbol", 14.25F);
+            dataGridViewCellStyle2.ForeColor = System.Drawing.Color.Black;
+            this.Note.DefaultCellStyle = dataGridViewCellStyle2;
+            this.Note.FillWeight = 23.01949F;
+            this.Note.HeaderText = "Note";
+            this.Note.MinimumWidth = 35;
+            this.Note.Name = "Note";
+            this.Note.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            this.Note.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            this.Note.Text = "";
+            // 
             // StockpileManagerForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -439,11 +447,6 @@
         #endregion
 
         public Components.DataGridViewDraggable dgvStockpile;
-        private System.Windows.Forms.DataGridViewTextBoxColumn Item;
-        private System.Windows.Forms.DataGridViewTextBoxColumn GameName;
-        private System.Windows.Forms.DataGridViewTextBoxColumn SystemName;
-        private System.Windows.Forms.DataGridViewTextBoxColumn SystemCore;
-        private System.Windows.Forms.DataGridViewButtonColumn Note;
         public System.Windows.Forms.Button btnRenameSelected;
         private System.Windows.Forms.Button btnImportStockpile;
         private System.Windows.Forms.Button btnStockpileMoveSelectedDown;
@@ -456,5 +459,11 @@
         public System.Windows.Forms.Button btnStockpileUP;
         public System.Windows.Forms.Button btnRemoveSelectedStockpile;
         public System.Windows.Forms.Button btnGlitchHarvesterSettings;
+        private System.Windows.Forms.DataGridViewTextBoxColumn Item;
+        private System.Windows.Forms.DataGridViewTextBoxColumn GameName;
+        private System.Windows.Forms.DataGridViewTextBoxColumn SystemName;
+        private System.Windows.Forms.DataGridViewTextBoxColumn SystemCore;
+        private System.Windows.Forms.DataGridViewTextBoxColumn EmuVer;
+        private System.Windows.Forms.DataGridViewButtonColumn Note;
     }
 }

--- a/Source/Frontend/UI/Components/Glitch Harvester/StockpileManagerForm.resx
+++ b/Source/Frontend/UI/Components/Glitch Harvester/StockpileManagerForm.resx
@@ -126,6 +126,9 @@
   <metadata name="SystemCore.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="EmuVer.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="Note.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -177,10 +180,11 @@
         XTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriXeW/h/sYH6AdFD6UeVjxS
         fNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2dmnafvvF05dOJZ+nPFmYKf5X+
         tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/MF72Rf3P4LeNt37vwd5MLWe+x7ys/
-        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALEQAACxEBf2RfkQAAAKpJREFUOE+dkAENwzAQ
-        AwuhEAZhUAqhUMZgEAZhEAahEAqhDP4rS/Hk/SdKM0tuo4/PTTq5+9Szmc1mtpmZl/edeykcHWD6YEkC
-        OvAeSpYEdWDMVi1JYAOmAWPve5IRWE/C9WcUVr+R/xd+kWPB7O7DsBZgeEU/sBYcMVlRgllwK4EtAKoq
-        zIK1hBZZq5owC3j/RynZr8IsUIDC7BnDNeNBAF/DFfBPUrDlE3aadkXmAozhAAAAAElFTkSuQmCC
+        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALEAAACxABrSO9dQAAALRJREFUOE+dkAEVwiAU
+        RReBCEYwyiIsig2MYAQjGGERFoEG4Ltz3/MFdMN3zv38AZeNDTnnXVJKQcwib+PZ1qrNJYVsRLEe0pQM
+        bSrlxfUcMjZF0GJLZm5yc/GobCCz9v6SHtnw13j0yp67CP/KN/PsgCC6ZbCGySP5kMGaKPZSyUA5CTJv
+        YytNGSiTIKOw3uerDBS7/0VwyLI+vfJTBooXLMxdRSWUUAgCb+MK/JNqY5s8PAF2mnZF2s6XPAAAAABJ
+        RU5ErkJggg==
 </value>
   </data>
   <data name="btnImportStockpile.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
@@ -230,10 +234,10 @@
         XTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriXeW/h/sYH6AdFD6UeVjxS
         fNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2dmnafvvF05dOJZ+nPFmYKf5X+
         tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/MF72Rf3P4LeNt37vwd5MLWe+x7ys/
-        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALEQAACxEBf2RfkQAAAJxJREFUOE+VkNsNhTAM
-        QxnhjsIIbMgIjMAod5RuYCOjFoU09BHJH03s0zYLyQXAD8AJYNd5RiX8B8Csw5taEkA3l/A0RIA9ALwg
-        AFYAyYdvQDYcAeCGlLDO2Wvn6SE1II8CwPs5PYjxbSGgB3G+GEBSf67Co4CVpLb9VdZbNaRWWNUFzOgT
-        0JpVPt+0AO3Dz4q2EcBQ+bDUW6StdAFJQHY2sKSSfgAAAABJRU5ErkJggg==
+        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALEAAACxABrSO9dQAAAKlJREFUOE+VkIENhDAM
+        AxnhR2EENmQERvhRGKUbtG9HDXIh4VVLJ9HENtCltbbUWj/gC3aeZ/DwCVrniIwZLOCbPTxdwoL9Fn6U
+        4HkFRYOOG44eepQAC/PcvbovVxMOWclFUDB+DgavJeLbfDYU9GVacvPZbAh3+M+PMFGfzzRIVsDbzqRe
+        kw7IW5hSr0kHs5jSBRTtFFO6gHgf0Z5swBQtpxQV/LtIUSs/SUB2NtIifVkAAAAASUVORK5CYII=
 </value>
   </data>
   <data name="btnLoadStockpile.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
@@ -283,10 +287,10 @@
         XTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriXeW/h/sYH6AdFD6UeVjxS
         fNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2dmnafvvF05dOJZ+nPFmYKf5X+
         tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/MF72Rf3P4LeNt37vwd5MLWe+x7ys/
-        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALEQAACxEBf2RfkQAAAJxJREFUOE+dkmENhTAQ
-        gycBCUiYlCcBCUjAyZOAhCcBCUjAQY90YS+XhmS7Nfn+cGnpbUtmlgAcAMxxAcictaB5E3OFoZMaFAbw
-        b2pusfsAHfbw04CPVuulrKAfIzCg7ANgfqnahMb1CVh02MHFGvNT52tx7X6fU6cdWquZLUaUawDPISo2
-        TjWANxEVz+wfwLcQ1eIDRlRuz9/CEDf7vZ1M5vSxowAAAABJRU5ErkJggg==
+        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALEAAACxABrSO9dQAAAJ1JREFUOE+dkgENgCAQ
+        RYlgBCIYxQhGIIJNjGAEIxjBCDTgvM84d3NMOP725gbe8w50RORSShdDisjM2GuB4k0VaiCdakUaCPC1
+        muCPQwtqL7Q4v4JFFqzkEWobvUCQ5+GnL92YQGEoglVvdBLRhi/t7Iw1h57nxooxQYrRxUhmEeAcrEHH
+        TgS4CWtwZq8A/4I1K/MKRpJvTwSDkHsA+72dTIElti4AAAAASUVORK5CYII=
 </value>
   </data>
   <data name="btnSaveStockpile.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
@@ -336,9 +340,10 @@
         XTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriXeW/h/sYH6AdFD6UeVjxS
         fNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2dmnafvvF05dOJZ+nPFmYKf5X+
         tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/MF72Rf3P4LeNt37vwd5MLWe+x7ys/
-        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALEQAACxEBf2RfkQAAAGNJREFUOE9j+Pfv338y
-        8fl///4ZMGCRIAW/RzbAAIuC/////wepEUDjN8D4cAOgElgNQJZD59PeAKjzUbxAqgEoGK8BpGDqGQDS
-        CQUYighguKZhZIABFkW4MEgthgFkAYoNAAAAXJCYTmj9pQAAAABJRU5ErkJggg==
+        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALEAAACxABrSO9dQAAAHZJREFUOE+1j4ENgCAM
+        BB3BURjRDR3FDcBvI59Sog2il1zSwvuRJedcXrrDNFMgHrYgmZkCyaxu3+rOguuCH9pze+f3/wug/H7z
+        hNGCxseCEb8rwFLpQoEKB+ADkQoH4AORCgfgA5EKB5CgD90pWUWWKSYLSjkBAFyQmOuyT3AAAAAASUVO
+        RK5CYII=
 </value>
   </data>
   <data name="btnSaveStockpileAs.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
@@ -388,9 +393,10 @@
         XTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriXeW/h/sYH6AdFD6UeVjxS
         fNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2dmnafvvF05dOJZ+nPFmYKf5X+
         tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/MF72Rf3P4LeNt37vwd5MLWe+x7ys/
-        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALEQAACxEBf2RfkQAAAGNJREFUOE9j+Pfv338y
-        8fl///4ZMGCRIAW/RzbAAIuC/////wepEUDjN8D4cAOgElgNQJZD59PeAKjzUbxAqgEoGK8BpGDqGQDS
-        CQUYighguKZhZIABFkW4MEgthgFkAYoNAAAAXJCYTmj9pQAAAABJRU5ErkJggg==
+        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALEAAACxABrSO9dQAAAHZJREFUOE+1j4ENgCAM
+        BB3BURjRDR3FDcBvI59Sog2il1zSwvuRJedcXrrDNFMgHrYgmZkCyaxu3+rOguuCH9pze+f3/wug/H7z
+        hNGCxseCEb8rwFLpQoEKB+ADkQoH4AORCgfgA5EKB5CgD90pWUWWKSYLSjkBAFyQmOuyT3AAAAAASUVO
+        RK5CYII=
 </value>
   </data>
   <data name="btnClearStockpile.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
@@ -440,9 +446,9 @@
         XTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriXeW/h/sYH6AdFD6UeVjxS
         fNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2dmnafvvF05dOJZ+nPFmYKf5X+
         tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/MF72Rf3P4LeNt37vwd5MLWe+x7ys/
-        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALEAAACxABrSO9dQAAAG1JREFUOE/dkNEJwDAI
-        RDNCR+oo2bAjdCQ3OIuhB41Itf0qPTjOoD4kTVWbGcACYAWwA9AbbzbHPS5KMFixEOAbZfP89xdc/sA3
-        U48/CAC9mDGAdZYfBNjrFOssR/1TQC+mKQQ80QQQ301k8+0AH1SjwihVaIIAAAAASUVORK5CYII=
+        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDwAACw8BkvkDpQAAAGxJREFUOE9j+P//Pxj/
+        +/dPAIgdgHg/EP/Hg9cDsQNMH0zje6gkqfg9zABskkRhmPPJdwFSGGBTgBeDwwCLAQlE0tgNgLEJ0TD2
+        IDIAxIMCGJsQDQLD1YAEImkQwGoAKQDFgPcgERIAUP1/BgAfVKPCj/s2KQAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="btnRemoveSelectedStockpile.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
@@ -492,10 +498,11 @@
         XTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriXeW/h/sYH6AdFD6UeVjxS
         fNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2dmnafvvF05dOJZ+nPFmYKf5X+
         tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/MF72Rf3P4LeNt37vwd5MLWe+x7ys/
-        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALEQAACxEBf2RfkQAAAKpJREFUOE+lkYENhDAM
-        AxmBURiBUdiIEX4ERmEUNrBfQU1J0gbBfyRLqLEP1R1IDv+ofgCYABwAdgBjNAbPxwHMgkUNpOM5Ibq0
-        iwbSCatWBYg5LhUyJ2EHGG8gma4r/ADxJb6E1HADKBC5cwypDpLudSJgIimmu9kt5G1Yp0KehLPzE6KA
-        zCSFyZ/E3JtNAWKMY9vOIIvtwELcUyWQJZYoWoviuYVsGhZ9Afmzh/v0yYAkAAAAAElFTkSuQmCC
+        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALEAAACxABrSO9dQAAALNJREFUOE+lkYENgzAM
+        BBmBURiho7ARI3QERmEUNoj7H8VubOKqtJZOQPw+lGQSkb+wl1LKAk5wgLkPDTJPXYsNaVwk+I6ZKtFm
+        31BMgmccVjYVMBybhOsPMBomJphBJsl4b+EHiT/EmxIbJk5AEOCeR4PkRMbdjhsGC2DoUx3AJHeHtUzy
+        zXC2XiUqyEI8MP6J4VHtKmAwVn/amWTVQJS4q2pEyQout7A14rpCyQ7qsIhML/mzh/sb7RFnAAAAAElF
+        TkSuQmCC
 </value>
   </data>
   <data name="btnGlitchHarvesterSettings.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
@@ -545,12 +552,12 @@
         XTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriXeW/h/sYH6AdFD6UeVjxS
         fNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2dmnafvvF05dOJZ+nPFmYKf5X+
         tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/MF72Rf3P4LeNt37vwd5MLWe+x7ys/
-        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALEQAACxEBf2RfkQAAAO1JREFUOE+FU4ENhDAI
-        dISO4AiO8KP8CD+CGziSoziCGxyfI5yhWCMJCb0eV0CczGySA2gAdgAGYE34GhjvWs65giB+gijn+YY9
-        CoRIJt+88lW2qwJYEvkAsIUzFr6kahsD9Zz9V18iNuDto5I9GcAcw6PPTyJ5wvQjJZ8JZyyR3M5ap7/H
-        WaKciebinzW17HNTj1XASzUzDkwCas0FmCMBKstOM+Oi0Bm/4d5CtS2qIpmvfiMmxrvOCLLsaiTmlWV8
-        S2auLrWe7LkjDB7wRYqc1i1L+Jt1/JpM1Ww8j7BHAbajkq/fOX0p3nW/8x+3oID2q1PHcwAAAABJRU5E
-        rkJggg==
+        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALEAAACxABrSO9dQAAAPpJREFUOE+FkwENwzAM
+        BAehEAqhEAZlEAqhDAopUAqhDJr9RfnISVfN0qvO2/7YXvbKOTdc1zUJScjCFvitcsSmWNMcoOC7Jhqc
+        b1ys6QTAkHzDmO+2i6q+ixOFQ9gr8M0vNZfOJhzPHLHGW2rBOuSARGAkS7G+s8DywPwkAukNgyMUn4HH
+        t0gcZ3N73nSqZ4uyE++l/Kz6euSyN884CpRWZSzMAh6tCMiaAMq2U+ChAHzbE19GGG0X4Enm1k/14Yh1
+        Bknbo5HoIovdimXJQT9PZo6G+HhBeUgCNZNviPhnXX53EFCNxvkX12piMWAct9z+ztXHiIXd5NcXt6CA
+        9pFX4VEAAAAASUVORK5CYII=
 </value>
   </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/Source/Frontend/UI/Components/Settings/SettingsGeneralForm.cs
+++ b/Source/Frontend/UI/Components/Settings/SettingsGeneralForm.cs
@@ -149,7 +149,7 @@ namespace RTCV.UI
         private void nmSwapEmuTimeout_ValueChanged(object sender, EventArgs e)
         {
             Params.SetParam("SWAP_EMU_TIMEOUT", nmSwapEmuTimeout.Value.ToString());
-            VanguardImplementation.timeout = (int)nmSwapEmuTimeout.Value;
+            StockpileManagerUISide.timeout = (int)nmSwapEmuTimeout.Value;
         }
 
         //todo - rewrite this?

--- a/Source/Frontend/UI/Components/Settings/SettingsGeneralForm.cs
+++ b/Source/Frontend/UI/Components/Settings/SettingsGeneralForm.cs
@@ -50,6 +50,10 @@ namespace RTCV.UI
                 decimal.TryParse(Params.ReadParam("AUTOSAVE_MAX_SIZE"), out decimal maxSize)
                 ? maxSize
                 : 2.5m;
+            if (int.TryParse(Params.ReadParam("SWAP_EMU_TIMEOUT"), out int timeoutSeconds))
+                nmSwapEmuTimeout.Value = timeoutSeconds;
+            else
+                nmSwapEmuTimeout.Value = 20;
         }
 
         private void OpenOnlineWiki(object sender, EventArgs e)
@@ -140,6 +144,12 @@ namespace RTCV.UI
         {
             Params.SetParam("AUTOSAVE_MAX_SIZE", nmMaxAutosaveSize.Value.ToString());
             AutoSave.SetMaxSize(this.nmMaxAutosaveSize.Value);
+        }
+
+        private void nmSwapEmuTimeout_ValueChanged(object sender, EventArgs e)
+        {
+            Params.SetParam("SWAP_EMU_TIMEOUT", nmSwapEmuTimeout.Value.ToString());
+            VanguardImplementation.timeout = (int)nmSwapEmuTimeout.Value;
         }
 
         //todo - rewrite this?

--- a/Source/Frontend/UI/Components/Settings/SettingsGeneralForm.designer.cs
+++ b/Source/Frontend/UI/Components/Settings/SettingsGeneralForm.designer.cs
@@ -30,6 +30,8 @@ namespace RTCV.UI
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SettingsGeneralForm));
             this.panel1 = new System.Windows.Forms.Panel();
+            this.label5 = new System.Windows.Forms.Label();
+            this.nmSwapEmuTimeout = new System.Windows.Forms.NumericUpDown();
             this.label3 = new System.Windows.Forms.Label();
             this.nmMaxAutosaveSize = new System.Windows.Forms.NumericUpDown();
             this.label2 = new System.Windows.Forms.Label();
@@ -51,6 +53,7 @@ namespace RTCV.UI
             this.btnWatchTutorialVideo = new System.Windows.Forms.Button();
             this.btnResetRandomSeed = new System.Windows.Forms.Button();
             this.panel1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nmSwapEmuTimeout)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nmMaxAutosaveSize)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nmAutosaveSeconds)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nmAutosaveMinutes)).BeginInit();
@@ -59,6 +62,8 @@ namespace RTCV.UI
             // panel1
             // 
             this.panel1.BackColor = System.Drawing.Color.Gray;
+            this.panel1.Controls.Add(this.label5);
+            this.panel1.Controls.Add(this.nmSwapEmuTimeout);
             this.panel1.Controls.Add(this.label3);
             this.panel1.Controls.Add(this.nmMaxAutosaveSize);
             this.panel1.Controls.Add(this.label2);
@@ -73,11 +78,46 @@ namespace RTCV.UI
             this.panel1.Controls.Add(this.cbDontCleanAtQuit);
             this.panel1.Controls.Add(this.cbAllowCrossCoreCorruption);
             this.panel1.Controls.Add(this.cbDisableEmulatorOSD);
-            this.panel1.Location = new System.Drawing.Point(18, 206);
+            this.panel1.Location = new System.Drawing.Point(18, 197);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(323, 177);
+            this.panel1.Size = new System.Drawing.Size(323, 196);
             this.panel1.TabIndex = 138;
             this.panel1.Tag = "color:normal";
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.Font = new System.Drawing.Font("Segoe UI", 8.25F);
+            this.label5.ForeColor = System.Drawing.Color.White;
+            this.label5.ImageAlign = System.Drawing.ContentAlignment.TopRight;
+            this.label5.Location = new System.Drawing.Point(55, 170);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(218, 13);
+            this.label5.TabIndex = 123;
+            this.label5.Text = "seconds before swapping emulators fails";
+            this.label5.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // nmSwapEmuTimeout
+            // 
+            this.nmSwapEmuTimeout.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(64)))), ((int)(((byte)(64)))));
+            this.nmSwapEmuTimeout.Font = new System.Drawing.Font("Segoe UI", 8F);
+            this.nmSwapEmuTimeout.ForeColor = System.Drawing.Color.White;
+            this.nmSwapEmuTimeout.Location = new System.Drawing.Point(11, 168);
+            this.nmSwapEmuTimeout.Maximum = new decimal(new int[] {
+            59,
+            0,
+            0,
+            0});
+            this.nmSwapEmuTimeout.Name = "nmSwapEmuTimeout";
+            this.nmSwapEmuTimeout.Size = new System.Drawing.Size(44, 22);
+            this.nmSwapEmuTimeout.TabIndex = 122;
+            this.nmSwapEmuTimeout.Tag = "color:dark1";
+            this.nmSwapEmuTimeout.Value = new decimal(new int[] {
+            20,
+            0,
+            0,
+            0});
+            this.nmSwapEmuTimeout.ValueChanged += new System.EventHandler(this.nmSwapEmuTimeout_ValueChanged);
             // 
             // label3
             // 
@@ -87,7 +127,7 @@ namespace RTCV.UI
             this.label3.ImageAlign = System.Drawing.ContentAlignment.TopRight;
             this.label3.Location = new System.Drawing.Point(223, 152);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(25, 13);
+            this.label3.Size = new System.Drawing.Size(24, 13);
             this.label3.TabIndex = 121;
             this.label3.Text = "GiB";
             this.label3.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -292,7 +332,7 @@ namespace RTCV.UI
             | System.Windows.Forms.AnchorStyles.Right)));
             this.label4.Font = new System.Drawing.Font("Segoe UI Semibold", 9F);
             this.label4.ForeColor = System.Drawing.Color.White;
-            this.label4.Location = new System.Drawing.Point(15, 188);
+            this.label4.Location = new System.Drawing.Point(15, 179);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(322, 15);
             this.label4.TabIndex = 139;
@@ -416,6 +456,7 @@ namespace RTCV.UI
             this.MouseDown += new System.Windows.Forms.MouseEventHandler(this.HandleMouseDown);
             this.panel1.ResumeLayout(false);
             this.panel1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nmSwapEmuTimeout)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nmMaxAutosaveSize)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nmAutosaveSeconds)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nmAutosaveMinutes)).EndInit();
@@ -445,5 +486,7 @@ namespace RTCV.UI
         private System.Windows.Forms.Label label2;
         public System.Windows.Forms.NumericUpDown nmMaxAutosaveSize;
         private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.Label label5;
+        public System.Windows.Forms.NumericUpDown nmSwapEmuTimeout;
     }
 }

--- a/Source/Frontend/UI/Components/Settings/SettingsGeneralForm.resx
+++ b/Source/Frontend/UI/Components/Settings/SettingsGeneralForm.resx
@@ -122,16 +122,15 @@
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAABEdEVYdENvcHlyaWdodABDcmVhdGl2ZSBDb21tb25z
-        IEF0dHJpYnV0aW9uIE5vbi1Db21tZXJjaWFsIE5vIERlcml2YXRpdmVze92woAAAAelJREFUWEftlttt
-        q0AQhreElEAJKcElpISUcEpwB5TgUiiBZ7TmYgvZ8o0gMGALPHM0ye4Gj5fESXyUh+Nf+uRhLv+sEQ8r
-        xF133WURAIwAwMOeAOAFACYA4PB+LQB4AoC4P6dmPfLk/VZ1XeeeTif8COrpuu6hN+NcO3e+jalt23Hb
-        tviPGfO9rzocDo/H4xEtTBQ8P4Sr4HkD7eL7RdM0XtM0yPB7dd9S55hXTLGlrvHMYlJVVaO6rpHh13Vt
-        DClWOd5nqKrK9FOs8vSr437v+0dZlqW33++xx8QUmajGes8oy9Il1LM5EMWs7+0tFEXhFEWBjMEDUM3S
-        P4Q5AMWWuiPyPP+T5zla8PM8NwYUqxzv+wyaI3ieGIssy7wsy3AA8xFSbKnbcBU8b8MXu90OP2K73U4I
-        nh/AvDGKLfULxGazwVuxXq/NASjmdRtitVrhjXEVPG9FLJdL/E3EYrHA30SkaYpX4incNE3HA1BN9/F5
-        K2I+n+MVPOuP61rRjMXnApEkSZwkCQ4xm82+vFyLZrkfIxZRFLlRFKGNOI6/vVyLPLhvD1eEYehMp1Pk
-        hGH44+Va5MX91Y63652U8llKiYoXKeUTN/mpyFN56z3nfzAIgscgCEZBEJi73q1F3mrH5Y3orv9WfwEX
-        d3YxT1VDmwAAAABJRU5ErkJggg==
+        IEF0dHJpYnV0aW9uIE5vbi1Db21tZXJjaWFsIE5vIERlcml2YXRpdmVze92woAAAAcxJREFUWEftltuN
+        glAQhk8JWwIlWAIlWIIlbAl0cEqgFErg2XhBjdF4N96Nl9kZHY54GIi7y8aH5U++OJz/nxkkPKBKlSol
+        6Xq9ukgACeH1AvERh2MpoVdFIm4xwrMAcTmWr/P5rC+XC+RBGeSDW6jHebWPW2SdTicPgT/G43XPOhwO
+        lePxCAI+I3kSmpG8G7SL1z603+8DBCxCtskPLU/CPGKqLS9JwLG7ttutu9vtwCJEzECq+czOGXCOyVPN
+        5/Qb18ns46Vcr9fBZrOBBD5bKZFnZZ/AWZrga3NDVMcZgnbejNVq5SBgkXkD5FnZPMwNUG15hKOWy+Un
+        AgIhYgZQzWdSNg/qIyTPU/P5PEAgA/MSUm15WWhG8mxCNZvNII/pdOoTkidgnhjVlieiJpMJFMV4PDY3
+        QLWUsVGj0QgKRjOSl0INh0N4J2owGMA7Uf1+H14kYDTiZUBenJNmpFC9Xg9eoMbv1suiHmuGiOp0OhEC
+        WXS73W8vj0W90swEkWq32xoBiSiKfrw8Fs2QZjNatVotp9lsgg2e/3p5LJqVseP+eddoNGoIMAukejMK
+        FM3k2fGe5z9Yr9criIuYb72iRbN5R/qLqNQ/lVJfF3d2McYPag8AAAAASUVORK5CYII=
 </value>
   </data>
   <data name="btnChangeRTCColor.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
@@ -181,13 +180,13 @@
         XTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriXeW/h/sYH6AdFD6UeVjxS
         fNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2dmnafvvF05dOJZ+nPFmYKf5X+
         tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/MF72Rf3P4LeNt37vwd5MLWe+x7ys/
-        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDAAACwwBP0AiyAAAAU5JREFUWEftVdsNwjAQ
-        6wiMwAiMwAiM0BHYhBEYgREYgREYoRtckaVEuthHG/r8wZIl5F7OTi+hjZl1ZtbvxK4JxE35DyAB+r5v
-        1iT7icALlib7iUDFZzN7ppty5GZTyH4iuEKYZ/3MjaaS/URwhe+kddxkDtlPhKDwxU3mkP1ESEUH0g/c
-        aCrZTwRXmEcA3rnRVLKfCK6wpWePJW4C+4lAxVf6WOH3hZv+QvYTgRekRbiSg1fRzE4pIHjl567u9wAV
-        xKH1ZwYMzw37QWTIogreuElCG9QWECFYMEYczCHw6AqIEBiM8cENCG+MaK0AY7vP8OehgAiuEPPDdwB4
-        JjMOgMa1yKMoIILbWTb38IeqdvcZ2IT4iZC0obnm1/nt5A8Bb6FAFKBmZwgRvaExyMiiAFK0ICR0FECK
-        1kQUYFP8AyDApjMndPlPZTeKsDU/0U9ZLqIi5QsAAAAASUVORK5CYII=
+        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDAAACwwBP0AiyAAAAWFJREFUWEftldFxgzAQ
+        RCnBJaSElOASUoJLcCcpISW4BJeQElwCHeDsariZ090hDrBxPrwzb4xXh7RCEnTDMPTg/iJ6BogaduMd
+        wAWAumdix/vfAfD/CK6AJ+VDt62FY2gmA+Cag4t/FH8rqs9CK8Bt9HrxHoGMI7QCiPcr3iNQ/RbCAPg9
+        GP+gO9mC6TcOMBbKEpAf8bei+iy0ApxM2wVsPgmmz+kAY/EZ6I8Vr790zVJUX4VmAAE+j2TzKKL9EzAg
+        OUc1BG3VeKkACbhp9Z4h4b4xNcW0cjcl+AaRTsDWVnIGZG+YgxuzJbt0lZwB6eIMF9DSDej3SCVnQFKY
+        YW72Ir0fKjkDkkKuH78D1BVE7wB2nJUsRSVnQPQ4mAyupTdVdvYiTiIdoLWu8jindn5LfAqVogCZmTFE
+        9ITm5JYsCrBkXZfKhY4CrJnZakUBdtU7AAPsuuZGPQO8lNDcj3v3B9FPWS4WmZm+AAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="btnOpenOnlineWiki.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
@@ -237,47 +236,45 @@
         XTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriXeW/h/sYH6AdFD6UeVjxS
         fNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2dmnafvvF05dOJZ+nPFmYKf5X+
         tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/MF72Rf3P4LeNt37vwd5MLWe+x7ys/
-        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDAAACwwBP0AiyAAAAQ5JREFUWEftleENwkAI
-        RjtCR3AER+gIjuIIbuIIjuIIHcENOEPCJecHV1pCE5uU5P3BAk+5nkMpZWghogcRlSAz12PPJXD4aDSN
-        8MRBPTIE3vLNMb9KQiWMRh53AfOMK6ESRhOPScB8ZVFCJYwGHjzcW11XQiWMYo9J6qxz0GJKqIRR6FEF
-        XsZniHpFMwWuRPQxPm+ZcV6aQCPBv0RXBOdlCNywh/S5yAHlm5Xvit0EuHl9FS34jthVYBM47xAC6tVZ
-        i/XPis9YRSkCcjumCKSC85QAP7FzbBYIrUDgWoyfZ7CAwYgKjFkC2XE8gegKmJQVRAXOM9CLzQLRFTAp
-        K4gKnGegF/8vYO0tK9R5+gKT0jibTdxO4gAAAABJRU5ErkJggg==
+        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDAAACwwBP0AiyAAAAUZJREFUWEftldFxAjEM
+        RCmBElJCSqCElJIS6CQlpJSUQAnp4BwtI8945eWUM/YfmnkfK7zSAuY4lVKIbduuRhnkZlzjzD1ImPnc
+        DHuGr3buHiTMOBLgx8A7j/1/hegaYlDGp6NeS0N0DTEk4+Ko18BuiK4hBmRgefbVPQzRNYQ54+I+dQ9a
+        ZIiuIYwZNcB36Cu6nygJIEwZNcC78dv0Fbe4jwQQpox7APciBD6Jh0Hq2QoJoEwJH3GGz3kzcEHxZMWz
+        4n4+niMB6sEDYHj9KSrwjFga4BBxHwmgTDOJ+0gAYTr079YCb5hlbT5DAkSDMRTAfHg6TgkwlbiPhLO6
+        aB8JJ9bwHTDgjUVnSDixRgOcjSkBZhftI+GsLtpHwon1ugOzi/aRcFYX7SPhxHrdgdlF+0g4q4v2kXBW
+        F+0j4ajvbVaF+1ROf5PSOJuTrp9HAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="btnWatchTutorialVideo.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAAfdEVYdENvcHlyaWdodABST1lBTFRZIEZSRUUgTElD
-        RU5TRSDe2YtpAAACD0lEQVRYR+2X223qQBCGUwIlUAIlUIJLSCl0QAkpISWkBN5ti7Wx19gm+H5jsT1H
-        EGnDrMbhYoW8nF/6nnbm+0fiBb+8/M9F+r7X+r5n8Ms5dZy6UHnXdVrXdfBkvo9o25a1bQtPhp3LhRCT
-        4/EIf4E8QAgBA6yEEEshREy8jUb+BE3TwACz0/vhcJg0TbMk3kchD6jrGijkwPfctK7rd3XuUaS4qiqg
-        QO0XqapqXlXVSp2/FyksyxIoUCuRsixfy7Jk6t6tSFGe50CB2gZSFMWkKIpFnuexun8NKcmyDChQ05Vk
-        WTbNsuxNdfyEXE7TFChQw41J03SepumH6qKQS0mSAAUy35kkSbQkSZjqJP1RFAEFMj6YOI4XURTFqhv5
-        9/s9UCDTiOz3+5nqRv7Pz0+gQJYR2e12M9WN/GEYAgWyPJgwDBdhGMaqG/mDIAAKZLozvu9rQRAw1Un6
-        fd8HCmS8Mdvtdu77/ofqorhcAgpkvhLP86ae572pjp+Qy5xzoEANA+GcTzjnC855rO5fQ0pc1wUK1ETE
-        cZxX13WZuncrlyKgQG0X2Ww2c8dxVur8vUihbdtAgVq/5qa2bb+rc48ixZZlwQDnv2SWZU0sy1oS76OQ
-        BzDGYIAVY2zJGIuJt9HIA9brNfwF8gDTNJlpmvBkvj5MTjEMQzMMA54M/j7UdV3TdZ3pug6/zKnjXP4P
-        tKUWKSOFBIkAAAAASUVORK5CYII=
+        RU5TRSDe2YtpAAAB8klEQVRYR+3XyXHCQBAF0A5BIRACIRCCQnAoZEAIDsEhOATuQDHsO4h9h/YfuY3H
+        cgsDwvjiX/UKSr3pCPQfN8fj0QfDvxx7w96Ss+85HA4+8IN9vsR+vzfAD2bC49vt1tvtdvwXTi8AHCMP
+        OQicZ3cTvoDNer3mGGlb32w2Hr7nIrXEwuM2q9WKNVI+Bc9S8OL2JCFriZbLJWuk/C2oZSDv9t5C1hEt
+        FgvWSDk26HkC485cQ9YQzWYz1kj5bObzuQdZ9AfR+Z/ICqLpdMoaKV8U9Kfg2Z3/iYwSTSYT1kj5qmAu
+        A6/unjgyQjQej1kj5ZuCeR+Muy9KWolGoxFrpJwoQRBksSuI7rakhWg4HLJGyomDXenobkvKRIPBgDVS
+        Tpx+v58+u7/X67FGyomCPVkI3L0fpIWo2+2yRso3pdPp+Nhhojtd0ho2s0bKV6Xdbmcw+xrdpZGRcIg1
+        Ur4orVYrBc/anjgyStRsNlkj5bNBnwdZCD7mLiUriBqNBmukHJt6vf6EPhOdu5SsCRexRsrfUqvVMqjn
+        o/3XknVE1WqVNVI+Bc9S8OL2JCFriSqVCscIf5Lh04Oc8/wuwuM2xhiOkYccBM6zu5HzROVymf+CnCcq
+        lUoG+MHe/5jYFItFH/jBvv4/LBQKPhjgX2Zv4DjRG7SlFindQl+nAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="btnResetRandomSeed.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAABl0RVh0U29m
         dHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAAfdEVYdENvcHlyaWdodABST1lBTFRZIEZSRUUgTElD
-        RU5TRSDe2YtpAAACvElEQVRYR72U4XHiMBCFKYESKOFKoBRKuBLo4EpQCZTgEu432MYYJ2BsjBTLAScQ
-        9uZlZE5Z7GASyJv5ZmztvrdCIDqdL+p4PA7JCM+8fle9vb31jscjBp/AGu+7mw6HgzgcDsQQvO8u2u/3
-        vf1+Tw3c/xReXl7E6+srGaTh/R013n9TlWXZK8uSLP6UZSnY2v1OYbfbid1uRxVmQz17DT3cdxNtt9ve
-        drsli9MgPLPabU+hKIpuURSj5+dnsjgNwbNdQy88H1MuSGvd1Vr3tdYDrfVQaz3SWjtFUSCQc3bMWKvp
-        I2SYLGQiGzP+by7P80Ge5zLPc2qL1vrsiLHG+y6AmYPO09MTXUnj3y5qNf2f0lFKUQ2OUmqklBoqpQZK
-        qb5SqvV3il7jgRcZyEImn0MdKeVISkkVm81GbjabXzz0u0Imsu1ZmP1ezLJMZFlGFjLLspttAlkm057x
-        8Ye8Xq/Fer0mC5mm6bc3gQxkseyzW/SuNE1FmqZkIZMk+fIm4EUGy6wfXilJEpEkCVWsViu5Wq2u3gQ8
-        8NpZyOZ9tYrjWMRxTBYyjuOzu98k9BqPndFueKXlcimWyyVZtL6G6GXe64ZDi8ViuFgsyBDw+iXBY/kb
-        /7wa9fDwIB4fH8ng8PolwVP5kcXrFxVFkRNFERlqP0EURV3A1yF4LP/VH6Azn8/JYlBTH87nc2k42yA8
-        dgavf6owDHthGJJFv6rNZrNBGIYBq4MANSujz+qtbxGG9GezGVVgLQiCQRAEGHJarwM96DU5du30IS5q
-        Op0Op9MpWfxl7xWOga/Xec6+pkb5vi9836dPCHzfPx03ns0a77NpfxM8z3M8z6MaAs/zzn6QlVAzPdwH
-        2t8E13WF67pkIV3X/c37moRe47Ez2p/AZDLpjsdjMR6PnclkMsQ777kkeOBFBrK+kvEj+gficLNe6Q8Y
-        7gAAAABJRU5ErkJggg==
+        RU5TRSDe2YtpAAACbUlEQVRYR72W6XHiQBCFFQIhEMKGQCgKYUNQBhvChEAICmF/gwFh8IXBDIeNbQ73
+        vke1tONBhgGDX9VXpenj9WhAKkWn6uPjIxEVrzX8M9psNlUM5eACxjR9ea3XawPEw2j6slqtVlUgX3D5
+        U3h/fzfL5VIUq2zXzGnZZfT29lYF4vAHGC92uVN4fX01QHI4jLgxcJlTWCwWVSAOxSBee7nznsLz83MF
+        1F9eXsShGMJrN8da9mg6TPP5vAJqIAYJqIMURjT02TlmxryaLfRQL3rSmzP+b242m8XAAgkFBjtHzFhZ
+        7R44M46m06kcyZevXea82oNEk8lESkhBHSQgBjUQ/JuyVnvYSw960XNnVmStrQPJGY/HFvxSr7OJnvR2
+        Z4H6Nvn09GSAOFhwtk3QSz3dGZ//yKPRyABxsMPh8NuboAe9PO/ylxWKDRAH+/j4ePIm2EsPz3P/mxJN
+        BkjOYDCw4OhNsIe9rhfYPzzXw8ODAeJgQfDrlbXa43qEDc91f39vgDgEP4as9XqPG07d3d0lQJRMw8Fi
+        j9N//Dfjzc2Nub29FSXVcLDYk/fTS8Ph6vf7KRCl9A4QrxBdfhJ7tJccfQNRr9cTh1jDhRBLgFV2Nsge
+        UHhoOEzX19dVIA41TUXdbjfGOvPyJGNOy+hR8/LhHykwqgHJYSzLshhwSBEvgzXQdiNerriJg+p0OgkQ
+        h7/eOidVynJ+T/iT0G63DZA9ZKA4bl5rrKw2J/xJaLVaKZASMrDzh8zFnNaU9YY/CVdXVwaIgwW/NX1Q
+        rNUe1yP8BJrNZqXRaBiQ4jrhWlPBYg976UGvUzx+QFH0D+Jws14qr815AAAAAElFTkSuQmCC
 </value>
   </data>
 </root>

--- a/Source/Frontend/UI/Forms/BlastEditorForm.cs
+++ b/Source/Frontend/UI/Forms/BlastEditorForm.cs
@@ -1810,7 +1810,7 @@ namespace RTCV.UI
             //Let's hope the game name is correct!
             File.Copy(filename, currentSK.GetSavestateFullPath(), true);
 
-            if (currentSK.EmuVer != new DirectoryInfo(RtcCore.EmuDir).Name)
+            if (!String.Equals(currentSK.EmuVer, new DirectoryInfo(RtcCore.EmuDir).Name, StringComparison.OrdinalIgnoreCase))
             {
                 if (!(await VanguardImplementation.SwapImplementation(currentSK.EmuVer)))
                     return;
@@ -2082,7 +2082,7 @@ namespace RTCV.UI
 
             var newSk = (StashKey)currentSK.Clone();
 
-            if (newSk.EmuVer != new DirectoryInfo(RtcCore.EmuDir).Name)
+            if (!String.Equals(newSk.EmuVer, new DirectoryInfo(RtcCore.EmuDir).Name, StringComparison.OrdinalIgnoreCase))
             {
 
                 if (!(await VanguardImplementation.SwapImplementation(newSk.EmuVer)))

--- a/Source/Frontend/UI/Forms/BlastEditorForm.cs
+++ b/Source/Frontend/UI/Forms/BlastEditorForm.cs
@@ -1814,6 +1814,7 @@ namespace RTCV.UI
             {
                 if (!(await VanguardImplementation.SwapImplementation(currentSK.EmuVer)))
                     return;
+                LocalNetCoreRouter.Route(Endpoints.UI, NetCore.Commands.Remote.UnlockInterface, true);
             }
 
             //Attempt to load and if it fails, don't let them update it.
@@ -2086,6 +2087,7 @@ namespace RTCV.UI
 
                 if (!(await VanguardImplementation.SwapImplementation(newSk.EmuVer)))
                     return;
+                LocalNetCoreRouter.Route(Endpoints.UI, NetCore.Commands.Remote.UnlockInterface, true);
             }
 
             S.GET<GlitchHarvesterBlastForm>().IsCorruptionApplied = await newSk.Run();

--- a/Source/Frontend/UI/Forms/BlastEditorForm.cs
+++ b/Source/Frontend/UI/Forms/BlastEditorForm.cs
@@ -57,8 +57,9 @@ namespace RTCV.UI
     using RTCV.NetCore;
     using RTCV.Common;
     using RTCV.UI.Components;
+    using System.Threading.Tasks;
 
-    #pragma warning disable CA2213 //Component designer classes generate their own Dispose method
+#pragma warning disable CA2213 //Component designer classes generate their own Dispose method
     public partial class BlastEditorForm : Modular.ColorizedForm
     {
         private const int buttonFillWeight = 20;
@@ -1779,7 +1780,7 @@ namespace RTCV.UI
             originalSK.StateLocation = temp.StateLocation;
         }
 
-        public void ReplaceSavestateFromFileToolStrip(string filename = null)
+        public async void ReplaceSavestateFromFileToolStrip(string filename = null)
         {
             if (filename == null)
             {
@@ -1809,8 +1810,14 @@ namespace RTCV.UI
             //Let's hope the game name is correct!
             File.Copy(filename, currentSK.GetSavestateFullPath(), true);
 
+            if (currentSK.EmuVer != new DirectoryInfo(RtcCore.EmuDir).Name)
+            {
+                if (!(await VanguardImplementation.SwapImplementation(currentSK.EmuVer)))
+                    return;
+            }
+
             //Attempt to load and if it fails, don't let them update it.
-            if (!StockpileManagerUISide.LoadState(currentSK))
+            if (!(await StockpileManagerUISide.LoadState(currentSK)))
             {
                 currentSK.ParentKey = oldKey;
                 currentSK.SyncSettings = oldSS;
@@ -2064,7 +2071,7 @@ namespace RTCV.UI
             }
         }
 
-        public void LoadCorrupt(object sender, EventArgs e)
+        public async void LoadCorrupt(object sender, EventArgs e)
         {
             if (currentSK.ParentKey == null)
             {
@@ -2073,10 +2080,18 @@ namespace RTCV.UI
             }
 
             var newSk = (StashKey)currentSK.Clone();
-            S.GET<GlitchHarvesterBlastForm>().IsCorruptionApplied = newSk.Run();
+
+            if (newSk.EmuVer != new DirectoryInfo(RtcCore.EmuDir).Name)
+            {
+
+                if (!(await VanguardImplementation.SwapImplementation(newSk.EmuVer)))
+                    return;
+            }
+
+            S.GET<GlitchHarvesterBlastForm>().IsCorruptionApplied = await newSk.Run();
         }
 
-        public void LoadOriginal()
+        public async void LoadOriginal()
         {
             if (currentSK.ParentKey == null)
             {
@@ -2086,13 +2101,13 @@ namespace RTCV.UI
 
             var newSk = (StashKey)currentSK.Clone();
             newSk.BlastLayer.Layer.Clear();
-            newSk.Run();
+            await newSk.Run();
         }
 
-        public void Corrupt(object sender, EventArgs e)
+        public async void Corrupt(object sender, EventArgs e)
         {
             var newSk = (StashKey)currentSK.Clone();
-            S.GET<GlitchHarvesterBlastForm>().IsCorruptionApplied = StockpileManagerUISide.ApplyStashkey(newSk, false);
+            S.GET<GlitchHarvesterBlastForm>().IsCorruptionApplied = await StockpileManagerUISide.ApplyStashkey(newSk, false);
         }
         
         private void RefreshNoteIcons()

--- a/Source/Frontend/UI/Forms/BlastGeneratorForm.cs
+++ b/Source/Frontend/UI/Forms/BlastGeneratorForm.cs
@@ -339,7 +339,8 @@ namespace RTCV.UI
                         SystemCore = psk.SystemCore,
                         GameName = psk.GameName,
                         SyncSettings = psk.SyncSettings,
-                        StateLocation = psk.StateLocation
+                        StateLocation = psk.StateLocation,
+                        EmuVer = psk.EmuVer
                     };
                 }
                 else
@@ -394,7 +395,8 @@ namespace RTCV.UI
                         SystemCore = psk.SystemCore,
                         GameName = psk.GameName,
                         SyncSettings = psk.SyncSettings,
-                        StateLocation = psk.StateLocation
+                        StateLocation = psk.StateLocation,
+                        EmuVer = psk.EmuVer
                     };
                 }
                 else
@@ -518,7 +520,8 @@ namespace RTCV.UI
                             SystemCore = psk.SystemCore,
                             GameName = psk.GameName,
                             StateLocation = psk.StateLocation,
-                            SyncSettings = psk.SyncSettings
+                            SyncSettings = psk.SyncSettings,
+                            EmuVer = psk.EmuVer
                         };
                     }
                     else

--- a/Source/Frontend/UI/Forms/BlastGeneratorForm.cs
+++ b/Source/Frontend/UI/Forms/BlastGeneratorForm.cs
@@ -349,7 +349,7 @@ namespace RTCV.UI
                     newSk = (StashKey)_sk.Clone();
                 }
 
-                if (newSk.EmuVer != new DirectoryInfo(RtcCore.EmuDir).Name)
+                if (!String.Equals(newSk.EmuVer, new DirectoryInfo(RtcCore.EmuDir).Name, StringComparison.OrdinalIgnoreCase))
                 {
                     
                     if (!(await VanguardImplementation.SwapImplementation(newSk.EmuVer)))

--- a/Source/Frontend/UI/Forms/BlastGeneratorForm.cs
+++ b/Source/Frontend/UI/Forms/BlastGeneratorForm.cs
@@ -11,6 +11,7 @@ namespace RTCV.UI
     using RTCV.NetCore;
     using RTCV.Common;
     using RTCV.UI.Components;
+    using System.Threading.Tasks;
 
     // 0  dgvBlastProtoReference
     // 1  dgvRowDirty
@@ -31,7 +32,7 @@ namespace RTCV.UI
     //TYPE = BLASTUNITTYPE
     //MODE = GENERATIONMODE
 
-    #pragma warning disable CA2213 //Component designer classes generate their own Dispose method
+#pragma warning disable CA2213 //Component designer classes generate their own Dispose method
     public partial class BlastGeneratorForm : Form, IColorize
     {
         private enum BlastGeneratorColumn
@@ -305,7 +306,7 @@ namespace RTCV.UI
             }
         }
 
-        private void LoadAndCorrupt(object sender, EventArgs e)
+        private async void LoadAndCorrupt(object sender, EventArgs e)
         {
             string saveStateWord = "Savestate";
 
@@ -346,6 +347,13 @@ namespace RTCV.UI
                 else
                 {
                     newSk = (StashKey)_sk.Clone();
+                }
+
+                if (newSk.EmuVer != new DirectoryInfo(RtcCore.EmuDir).Name)
+                {
+                    
+                    if (!(await VanguardImplementation.SwapImplementation(newSk.EmuVer)))
+                        return;
                 }
 
                 BlastLayer bl = GenerateBlastLayers(true, true);

--- a/Source/Frontend/UI/Forms/BlastGeneratorForm.cs
+++ b/Source/Frontend/UI/Forms/BlastGeneratorForm.cs
@@ -354,6 +354,7 @@ namespace RTCV.UI
                     
                     if (!(await VanguardImplementation.SwapImplementation(newSk.EmuVer)))
                         return;
+                    LocalNetCoreRouter.Route(Endpoints.UI, NetCore.Commands.Remote.UnlockInterface, true);
                 }
 
                 BlastLayer bl = GenerateBlastLayers(true, true);

--- a/Source/Frontend/UI/Forms/SimpleModeForm.cs
+++ b/Source/Frontend/UI/Forms/SimpleModeForm.cs
@@ -9,6 +9,7 @@ namespace RTCV.UI
     using RTCV.Common;
     using RTCV.UI.Components.Controls;
     using RTCV.UI.Modular;
+    using System.Threading.Tasks;
 
     public partial class SimpleModeForm : ComponentForm, IBlockable
     {
@@ -111,14 +112,14 @@ namespace RTCV.UI
             btnCreateGhSavestate.Text = "  Update the Glitch Harvester savestate";
         }
 
-        private void GlitchHarvesterLoadAndCorrupt(object sender, EventArgs e)
+        private async void GlitchHarvesterLoadAndCorrupt(object sender, EventArgs e)
         {
             if (S.GET<StashHistoryForm>().lbStashHistory.Items.Count >= 20)
             {
                 S.GET<StashHistoryForm>().RemoveFirstStashHistoryItem();
             }
 
-            S.GET<GlitchHarvesterBlastForm>().Corrupt(null, null);
+            await Task.Run(() => S.GET<GlitchHarvesterBlastForm>().Corrupt(null, null));
         }
 
         private void SelectClassicPlatforms(object sender, EventArgs e)

--- a/Source/Frontend/UI/Forms/StockpilePlayerForm.cs
+++ b/Source/Frontend/UI/Forms/StockpilePlayerForm.cs
@@ -181,11 +181,11 @@ namespace RTCV.UI
                     .AddItem("Load on Select", (ob, ev) => S.GET<GlitchHarvesterBlastForm>().LoadOnSelect = !loadOnSelect, isChecked: loadOnSelect)
                     .AddItem("Clear Infinite Units on Rewind", (ob, ev) => S.GET<GeneralParametersForm>().cbClearFreezesOnRewind.Checked = !clearInfiniteUnitsOnRewind, isChecked: clearInfiniteUnitsOnRewind)
                     .AddItem(stripSeparator)
-                    .AddItem("Manual Inject", (ob, ev) =>
+                    .AddItem("Manual Inject", async (ob, ev) =>
                     {
                         var sk = GetSelectedStashKey();
                         StashKey newSk = (StashKey)sk.Clone();
-                        bool isCorrupted = StockpileManagerUISide.ApplyStashkey(newSk, false, false);
+                        bool isCorrupted = await StockpileManagerUISide.ApplyStashkey(newSk, false, false);
                         if (StockpileManagerUISide.CurrentStashkey != null)
                             S.GET<GlitchHarvesterBlastForm>().IsCorruptionApplied = isCorrupted;
                     }, dgvStockpile.SelectedRows.Count == 1)
@@ -205,7 +205,7 @@ namespace RTCV.UI
             }
         }
 
-        private async void LoadStockpile(string fileName)
+        private async Task LoadStockpile(string fileName)
         {
             try
             {

--- a/Source/Frontend/UI/Forms/StockpilePlayerForm.cs
+++ b/Source/Frontend/UI/Forms/StockpilePlayerForm.cs
@@ -48,7 +48,7 @@ namespace RTCV.UI
 
                     foreach (StashKey key in sks.StashKeys)
                     {
-                        dgvStockpile?.Rows.Add(key, key.GameName, key.SystemName, key.SystemCore, key.Note);
+                        dgvStockpile?.Rows.Add(key, key.GameName, key.SystemName, key.SystemCore, key.EmuVer, key.Note);
                     }
                 }
                 //Check for missing ref files
@@ -236,7 +236,7 @@ namespace RTCV.UI
                     {
                         foreach (StashKey key in sks.StashKeys) //Populate the dgv
                         {
-                            dgvStockpile?.Rows.Add(key, key.GameName, key.SystemName, key.SystemCore, key.Note);
+                            dgvStockpile?.Rows.Add(key, key.GameName, key.SystemName, key.SystemCore, key.EmuVer, key.Note);
                         }
                     });
                 }

--- a/Source/Frontend/UI/Modular/CoreForm.cs
+++ b/Source/Frontend/UI/Modular/CoreForm.cs
@@ -382,11 +382,11 @@ This message only appears once.";
             }
         }
 
-        public void ManualBlast(object sender, EventArgs e)
+        public async void ManualBlast(object sender, EventArgs e)
         {
             if (AllSpec.VanguardSpec[VSPEC.REPLACE_MANUALBLAST_WITH_GHCORRUPT] != null)
             {
-                S.GET<GlitchHarvesterBlastForm>().Corrupt(sender, e);
+                await Task.Run(() => S.GET<GlitchHarvesterBlastForm>().Corrupt(sender, e));
             }
             else
             {

--- a/Source/Frontend/UI/Modular/CoreForm.resx
+++ b/Source/Frontend/UI/Modular/CoreForm.resx
@@ -165,12 +165,12 @@
         XTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriXeW/h/sYH6AdFD6UeVjxS
         fNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2dmnafvvF05dOJZ+nPFmYKf5X+
         tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/MF72Rf3P4LeNt37vwd5MLWe+x7ys/
-        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALEQAACxEBf2RfkQAAAO1JREFUOE+FU4ENhDAI
-        dISO4AiO8KP8CD+CGziSoziCGxyfI5yhWCMJCb0eV0CczGySA2gAdgAGYE34GhjvWs65giB+gijn+YY9
-        CoRIJt+88lW2qwJYEvkAsIUzFr6kahsD9Zz9V18iNuDto5I9GcAcw6PPTyJ5wvQjJZ8JZyyR3M5ap7/H
-        WaKciebinzW17HNTj1XASzUzDkwCas0FmCMBKstOM+Oi0Bm/4d5CtS2qIpmvfiMmxrvOCLLsaiTmlWV8
-        S2auLrWe7LkjDB7wRYqc1i1L+Jt1/JpM1Ww8j7BHAbajkq/fOX0p3nW/8x+3oID2q1PHcwAAAABJRU5E
-        rkJggg==
+        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDwAACw8BkvkDpQAAAPpJREFUOE+FkwENwzAM
+        BAehEAqhEAZlEAqhDAopUAqhDJr9RfnISVfN0qvO2/7YXvbKOTdc1zUJScjCFvitcsSmWNMcoOC7Jhqc
+        b1ys6QTAkHzDmO+2i6q+ixOFQ9gr8M0vNZfOJhzPHLHGW2rBOuSARGAkS7G+s8DywPwkAukNgyMUn4HH
+        t0gcZ3N73nSqZ4uyE++l/Kz6euSyN884CpRWZSzMAh6tCMiaAMq2U+ChAHzbE19GGG0X4Enm1k/14Yh1
+        Bknbo5HoIovdimXJQT9PZo6G+HhBeUgCNZNviPhnXX53EFCNxvkX12piMWAct9z+ztXHiIXd5NcXt6CA
+        9pFX4VEAAAAASUVORK5CYII=
 </value>
   </data>
   <data name="btnEngineConfig.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
@@ -220,11 +220,11 @@
         XTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriXeW/h/sYH6AdFD6UeVjxS
         fNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2dmnafvvF05dOJZ+nPFmYKf5X+
         tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/MF72Rf3P4LeNt37vwd5MLWe+x7ys/
-        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALEQAACxEBf2RfkQAAAOBJREFUOE+lUwENwzAM
-        G4RBOKRBGIRDOINCGIRBGIRDGIQxsC+vyZ5n/XX9kay0ieNGaduR7P7BKQCgB1AArAAYoL3i/VsBAAOA
-        zQoW84rFvfLDSSAQ42m+ls9d7SKxbSnv6qn1DO9S6F1A6h7MBRGzeecWF1Br99B2C8qPtp5sJqsLZHIL
-        ccAHJHBhNQ1ltXW2K8kl7MUT/7jCT6ZCCTTNBaQoYskEkrccIDkZv87ACjfDN+bcegsk9TxzsbqarQP5
-        PB/x6zsw7EOxxBjiEYr7Qc+XmERePksDyp//wq94AKVTj4CXTXPBAAAAAElFTkSuQmCC
+        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDwAACw8BkvkDpQAAAOdJREFUOE+lkw0NgzAQ
+        hScBCZOEBCRMwhwgAQlIQMIkIAEHdO9r+1hXmmXLLvly5X4el6NcQgh/cQrs+96JUawiFPBMvCvr6+Ze
+        bIKGJXti5TP5/iRAMBeA3+Yzvp4qiriZsVGO6sJFLTwldBZA3cFWk5mzd+1oAUZ7EBB1kyE/5PMk2Mlq
+        gbq4RbngAwSuAmMpazqe7CaWdIxGHfXHJ/xkNCLQNAugSOEoartnX9okqE87EDRumW/MtekrCK5n3cxU
+        s2ACfL0f6tM9yMSlyEgMoswZ4n7R6yYWEHz7WRqQj81QJ38kXJ6lU4+AGelrhgAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="btnEasyMode.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
@@ -274,10 +274,11 @@
         XTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriXeW/h/sYH6AdFD6UeVjxS
         fNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2dmnafvvF05dOJZ+nPFmYKf5X+
         tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/MF72Rf3P4LeNt37vwd5MLWe+x7ys/
-        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALEQAACxEBf2RfkQAAAKRJREFUOE+lkQsNhEAM
-        RJGABCQgBQlIQAIOTgJSkHIScDBDJplL9s+Ga/KS3XZnKO1AcqgBYANwAZiMzlv4JhMlBrNFO4DD57nL
-        wF+UwWqhWJybegzYosfgvw5s8n4GNni/BbcbPS6RJYxaj4ZVI0uYU0qSn0Lt0WC1+CI5FupNAwkkVMgo
-        rWekCbWs0C+ktSLhRfv9RbTrFuGle3A1g695HFzIDbtoKlnyCpMlAAAAAElFTkSuQmCC
+        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDwAACw8BkvkDpQAAALVJREFUOE+lkQsRw0AI
+        RCOhEiIhUiohEiKhDiqhUiqlEuLg6O4MpMCR9MfMmzlg90K4QUR2aa0tYAWjwvPiNcGQgXhS0wXc9Dx5
+        TTB4IOQXecGsRnLW2mi6zmhAJEeYrjMaEP03AVExjd/vgED8+ytAyHGDuKIsAo4elrVHWQR3wLiCqr9R
+        FWfAWMEJVJqNXKCBRgYvyv2OXODIDP5C7pX4hO9rEd76CJ98vDiPTx7K28W9kOEJu2gqWYdEtlQAAAAA
+        SUVORK5CYII=
 </value>
   </data>
   <data name="btnStockpilePlayer.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
@@ -327,10 +328,10 @@
         XTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriXeW/h/sYH6AdFD6UeVjxS
         fNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2dmnafvvF05dOJZ+nPFmYKf5X+
         tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/MF72Rf3P4LeNt37vwd5MLWe+x7ys/
-        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALEQAACxEBf2RfkQAAAIJJREFUOE+lklENgDAM
-        RJGABKQgBSk4QQoSkDIH98gSSOCWMQpN3sea3rXp2gHdH4pElNtDUpK0SBq8sIYbcGGW1LvAeTLI5Ikm
-        F0UMTjZJo4sjBier7ydqkFmqBrRjBeoTePUlNqC9A1cBCXj/CyaegdgdHB3zkr5d4heKRJQiEWUHM3U7
-        Ejczx1UAAAAASUVORK5CYII=
+        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDwAACw8BkvkDpQAAAIdJREFUOE+l0tsNwCAI
+        BVBH6AgdpaN0FDdxFEdwFDeQXj6aAMH6KMn5gAoaayCiX9ziCpW01iokOGX9i0rQSEKEQ373qMQMYHyi
+        W66xVGKapQKXXPtSiWnyZFD3szqAJdmjBsAoMvRPAL0oML4DsFFh/i+AjAhr7wB4R76kvZe4wy2ucIvz
+        KDwzdTsSxVd1tAAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="btnGlitchHarvester.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
@@ -380,11 +381,11 @@
         XTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriXeW/h/sYH6AdFD6UeVjxS
         fNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2dmnafvvF05dOJZ+nPFmYKf5X+
         tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/MF72Rf3P4LeNt37vwd5MLWe+x7ys/
-        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALEQAACxEBf2RfkQAAALxJREFUOE/NUsEJwzAQ
-        ywgZIaNklIyQEbKJR+gIGaUjdAOpyD3D+XyGQj81iMOKdHcWWUguv2AgGgAcAJ4AaPWImqEBgDUYI2oj
-        6boGZrwAvBJTBumkX1uDkoi+QfHr7wDuRJRBun3IwDWabSS+GrMMTnvXZtxmBk1T9bx00k8zeJDsJuku
-        Pm7UCUje7I/u14TPM7APJRjaET9mQFI/xmnT6lutyqBpqp6XTvpPBsnENAPj/fmjDDLMMujwBis4ccjQ
-        SA2UAAAAAElFTkSuQmCC
+        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDwAACw8BkvkDpQAAAMZJREFUOE/NktENwyAM
+        RDMCI2SUjJIRMkI2YYSOkFE6QjcIvUehNdRUqvpTpCeL44zDKVNK6SdcEc7zXMVVpFJXz9dsZAoYSwON
+        PfkiEZoLEMQubsJr7MGHP9QLYjn4lmg/fxGHOfwEvuX5BAsHYvRF6LmxUpvIYBO8ay7aLGhgGtXq+PAP
+        M7hIbyaxR+98rwwwiEPYxX4v1S72fgaCgyi8hf6egeDH2ATT8ltLpYFpVKvjw//IQPQT3QwEul1/lIHH
+        KANDmu4rOHHIUgsiSgAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="btnManualBlast.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
@@ -434,11 +435,11 @@
         XTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriXeW/h/sYH6AdFD6UeVjxS
         fNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2dmnafvvF05dOJZ+nPFmYKf5X+
         tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/MF72Rf3P4LeNt37vwd5MLWe+x7ys/
-        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALEQAACxEBf2RfkQAAALFJREFUOE+lk8ERAiEM
-        RVPKlmAJXnK3BEuwBDuxBEuwFEuJ83b4TMQFnN3DG0hCPiGARYQdwcKHnMItwm3ZiK38OBrORYCxjQ0F
-        7uH2LskCG/9U4FESnuF2KXNGbObEuwLswKJr8mFrjh+7VtIKUCY7ZV8WAOKs+xKgy2oY5Y4EdCzWL0rO
-        zWp5bfgqUuW+RxUQE+pTrSCzuwfi31u49QTg0DsQvZdYd54JiN1/QUx/4we4Zac/X41MggAAAABJRU5E
-        rkJggg==
+        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDwAACw8BkvkDpQAAAL9JREFUOE+lk8ERgkAM
+        RbcUSrAEL94pwRIswU4ogRIshVJinsPPZJ0IjBze7P6fZDcEaGZ2ima3TS6OOUPyOkozcXU4gLWK16bz
+        dBaHYoHG73I7sTI5FMzOuO5Z0eyJR34uBG4g6Z48tPb46OhEAUGb3JS9fAAQJ++jZTJlDYx25cP3AXos
+        8gcMijF+8Sq8QKfyvrc6ICY0p+gg8/cMxNG38JCnQObUdyDohDYpEOi4WXSiQINlreK1mdj5G1t7A7hl
+        pz8Fx4ZuAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="btnAutoCorrupt.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
@@ -488,12 +489,12 @@
         XTesb3QPLh88M+QwdP6m681Lt7xuXbu94vbgcOjwnZHokdE77DtTd1PuvriXeW/h/sYH6AdFD6UeVjxS
         fNTws+7PbaOWo6fHXMf6Hwc/vj/OGn/2S8Yv7ycKnpCfVEyqTDZPmU2dmnafvvF05dOJZ+nPFmYKf5X+
         tfa5zvMffnP8rX82YnbiBf/Fp99LXsq/PPRq2aueuYC5R69TXy/MF72Rf3P4LeNt37vwd5MLWe+x7ys/
-        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALEQAACxEBf2RfkQAAARFJREFUOE+Nkj0KwkAQ
-        hXMDLyCktbeNZSzFRkSwSiVCINpECNhYaGEjKAgGPYJX8ARewN7WzkZw9O1myGaz+SleYDf7vnkzuxYR
-        WUKuZVa/8aXjfJjbh4jkpxTgWkSzztOwXwJYDW50jmza+4EAQFjXBkzbL/Ja76SyBKCVrRfXA6hGVaPm
-        pxpwCh3Rgm5m4T+3YwSgCuLrRhbgy969GID+dZOqFK4B4tChS2RXAli4oQzg4AfCXDRAHYyCOYBuklOX
-        D0kfLM6XAmBYdB9Cu8m6GoD+swnkQHEQcTF5TmQEwIDXxpGx3oyvSTI5ZPV6czPAIcTl+DJRer1qi3Kg
-        2jViAyaugjRIgH3E53QwM/wP+AH+XDYo+PdCHQAAAABJRU5ErkJggg==
+        6H7o/ujz8cGn1E+f/gUDmPP8usTo0wAAAAlwSFlzAAALDwAACw8BkvkDpQAAAR9JREFUOE+FkrFKA0EQ
+        hu8NfAHB1t7WlJdSbCQIqa4SQUhsIgg2KZLCJhBByKGP4Cv4BL6Afdp0aQQn8+3ecHvJXK6Y5HZn/m//
+        md1MRGLkmR/XJ//y/jhwc6rrBuSaHvfWzv4RwPTmWz6ez2T5MNK1hGCd1hCtgPuLjRTn2+rkCKCV16Js
+        1LUCUmEat6d/+t8BWE0uQwsegCBv7bgATsG+JyaAv1z96LcuPAD9e0KLGq4/KaBUa59qrQtgwQ01AG+6
+        gbhtgPtgDjwApAVEnHp8SPuDpf4oAMFT/zfE4m7WDaD/tMAGSiF2mbw5cgEIeG0k7e3Ph1+Vszjk9HoP
+        ZkARdkliNzqqrzdtMQ406KLYAIjsFNzggH3smzvEBhfJdv5cNihqC9s+AAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/Source/Frontend/UI/Modular/SaveProgressForm.cs
+++ b/Source/Frontend/UI/Modular/SaveProgressForm.cs
@@ -53,7 +53,7 @@ namespace RTCV.UI
             logger.Trace("Entering OnShown() {0}\n{1}", System.Threading.Thread.CurrentThread.ManagedThreadId, Environment.StackTrace);
             lbCurrentAction.Text = "Waiting";
             pbSave.Value = 0;
-            if (!UICore.isSwapping)
+            if (!VanguardImplementation.isSwapping)
             {
             try
             {
@@ -70,7 +70,7 @@ namespace RTCV.UI
         public void OnHidden()
         {
             logger.Trace("Entering OnHidden() {0}\n{1}", System.Threading.Thread.CurrentThread.ManagedThreadId, Environment.StackTrace);
-            if (!UICore.isSwapping)
+            if (!VanguardImplementation.isSwapping)
             {
             VanguardImplementation.connector?.netConn?.Spec?.UnlockLockStatusEventLockout();
             logger.Trace("Thread id {0} released Mutex... (save)", System.Threading.Thread.CurrentThread.ManagedThreadId);

--- a/Source/Frontend/UI/Modular/SaveProgressForm.cs
+++ b/Source/Frontend/UI/Modular/SaveProgressForm.cs
@@ -53,6 +53,8 @@ namespace RTCV.UI
             logger.Trace("Entering OnShown() {0}\n{1}", System.Threading.Thread.CurrentThread.ManagedThreadId, Environment.StackTrace);
             lbCurrentAction.Text = "Waiting";
             pbSave.Value = 0;
+            if (!UICore.isSwapping)
+            {
             try
             {
                 VanguardImplementation.connector?.netConn?.Spec?.LockStatusEventLockout();
@@ -62,13 +64,17 @@ namespace RTCV.UI
             {
                 logger.Trace("AbandonedMutexException! Thread id {0} got Mutex... (save)", System.Threading.Thread.CurrentThread.ManagedThreadId);
             }
+            }
         }
 
         public void OnHidden()
         {
             logger.Trace("Entering OnHidden() {0}\n{1}", System.Threading.Thread.CurrentThread.ManagedThreadId, Environment.StackTrace);
+            if (!UICore.isSwapping)
+            {
             VanguardImplementation.connector?.netConn?.Spec?.UnlockLockStatusEventLockout();
             logger.Trace("Thread id {0} released Mutex... (save)", System.Threading.Thread.CurrentThread.ManagedThreadId);
+            }
         }
     }
 }

--- a/Source/Frontend/UI/UI.csproj
+++ b/Source/Frontend/UI/UI.csproj
@@ -44,6 +44,9 @@
     <Compile Update="Components\Advanced Tools\DomainAnalyticsForm.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Update="Components\Glitch Harvester\StockpileEmuVersionForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Update="Components\Settings\MyPluginsForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/Source/Frontend/UI/UIConnector.cs
+++ b/Source/Frontend/UI/UIConnector.cs
@@ -51,7 +51,7 @@ namespace RTCV.UI
 
             if (VanguardImplementation.isSwapping)
             {
-                VanguardImplementation.finishedClosing = true;
+                VanguardImplementation.finishedClosing.TrySetResult(true);
                 return;
             }
 

--- a/Source/Frontend/UI/UIConnector.cs
+++ b/Source/Frontend/UI/UIConnector.cs
@@ -7,6 +7,7 @@ namespace RTCV.UI
     using RTCV.NetCore.Enums;
     using RTCV.Common;
     using RTCV.UI.Modular;
+    using NLog;
 
     public class UIConnector : IRoutable, IDisposable
     {
@@ -42,7 +43,7 @@ namespace RTCV.UI
 
         private void NetCoreSpec_ServerConnectionLost(object sender, EventArgs e)
         {
-            if (UICore.isClosing || UICore.FirstConnect)
+            if (UICore.isClosing || UICore.FirstConnect || UICore.isSwapping)
             {
                 return;
             }

--- a/Source/Frontend/UI/UIConnector.cs
+++ b/Source/Frontend/UI/UIConnector.cs
@@ -8,6 +8,7 @@ namespace RTCV.UI
     using RTCV.Common;
     using RTCV.UI.Modular;
     using NLog;
+    using System.Windows.Forms;
 
     public class UIConnector : IRoutable, IDisposable
     {
@@ -48,9 +49,9 @@ namespace RTCV.UI
                 return;
             }
 
-            if (UICore.isSwapping)
+            if (VanguardImplementation.isSwapping)
             {
-                UICore.finishedClosing = true;
+                VanguardImplementation.finishedClosing = true;
                 return;
             }
 

--- a/Source/Frontend/UI/UIConnector.cs
+++ b/Source/Frontend/UI/UIConnector.cs
@@ -51,7 +51,7 @@ namespace RTCV.UI
 
             if (VanguardImplementation.isSwapping)
             {
-                VanguardImplementation.finishedClosing.TrySetResult(true);
+                StockpileManagerUISide.finishedClosing.TrySetResult(true);
                 return;
             }
 

--- a/Source/Frontend/UI/UIConnector.cs
+++ b/Source/Frontend/UI/UIConnector.cs
@@ -43,8 +43,14 @@ namespace RTCV.UI
 
         private void NetCoreSpec_ServerConnectionLost(object sender, EventArgs e)
         {
-            if (UICore.isClosing || UICore.FirstConnect || UICore.isSwapping)
+            if (UICore.isClosing || UICore.FirstConnect)
             {
+                return;
+            }
+
+            if (UICore.isSwapping)
+            {
+                UICore.finishedClosing = true;
                 return;
             }
 

--- a/Source/Frontend/UI/UICore.cs
+++ b/Source/Frontend/UI/UICore.cs
@@ -216,6 +216,7 @@ namespace RTCV.UI
 
                 if (focusCoreForm)
                 {
+                    cf.BringToFront();
                     cf.Focus();
                 }
             }

--- a/Source/Frontend/UI/UICore.cs
+++ b/Source/Frontend/UI/UICore.cs
@@ -21,9 +21,6 @@ namespace RTCV.UI
     public static class UICore
     {
         internal static bool FirstConnect = true;
-        internal static bool isSwapping = false;
-        internal static bool finishedClosing = false;
-        internal static bool finishedSwapping = false;
         internal static ManualResetEvent Initialized = new ManualResetEvent(false);
         private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 

--- a/Source/Frontend/UI/UICore.cs
+++ b/Source/Frontend/UI/UICore.cs
@@ -21,6 +21,7 @@ namespace RTCV.UI
     public static class UICore
     {
         internal static bool FirstConnect = true;
+        internal static bool isSwapping = false;
         internal static ManualResetEvent Initialized = new ManualResetEvent(false);
         private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 

--- a/Source/Frontend/UI/UICore.cs
+++ b/Source/Frontend/UI/UICore.cs
@@ -22,6 +22,8 @@ namespace RTCV.UI
     {
         internal static bool FirstConnect = true;
         internal static bool isSwapping = false;
+        internal static bool finishedClosing = false;
+        internal static bool finishedSwapping = false;
         internal static ManualResetEvent Initialized = new ManualResetEvent(false);
         private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 

--- a/Source/Frontend/UI/UICore.cs
+++ b/Source/Frontend/UI/UICore.cs
@@ -730,6 +730,9 @@ namespace RTCV.UI
 
                 S.GET<CoreForm>().btnAutoCorrupt.Visible = false;
             }
+
+            S.GET<GeneralParametersForm>().UpdateMaxIntensity();
+            S.GET<GlitchHarvesterIntensityForm>().UpdateMaxIntensity();
         }
 
         private static void toggleLimiterBoxSource(bool setToBindingSource)

--- a/Source/Frontend/UI/UICore.cs
+++ b/Source/Frontend/UI/UICore.cs
@@ -17,6 +17,7 @@ namespace RTCV.UI
     using RTCV.UI.Modular;
     using RTCV.NetCore.Commands;
     using System.Dynamic;
+    using System.Threading.Tasks;
 
     public static class UICore
     {
@@ -444,21 +445,21 @@ namespace RTCV.UI
                     break;
 
                 case "Load and Corrupt":
-                    SyncObjectSingleton.FormExecute(() =>
+                    SyncObjectSingleton.FormExecute(async () =>
                     {
                         S.GET<GlitchHarvesterBlastForm>().loadBeforeOperation = true;
-                        S.GET<GlitchHarvesterBlastForm>().Corrupt(null, null);
+                        await Task.Run(() => S.GET<GlitchHarvesterBlastForm>().Corrupt(null, null));
                     });
                     break;
 
                 case "Just Corrupt":
                     AllSpec.CorruptCoreSpec.Update(VSPEC.STEP_RUNBEFORE, true);
 
-                    SyncObjectSingleton.FormExecute(() =>
+                    SyncObjectSingleton.FormExecute(async () =>
                     {
                         bool isload = S.GET<GlitchHarvesterBlastForm>().loadBeforeOperation;
                         S.GET<GlitchHarvesterBlastForm>().loadBeforeOperation = false;
-                        S.GET<GlitchHarvesterBlastForm>().Corrupt(null, null);
+                        await Task.Run(() => S.GET<GlitchHarvesterBlastForm>().Corrupt(null, null));
                         S.GET<GlitchHarvesterBlastForm>().loadBeforeOperation = isload;
                     });
                     break;
@@ -478,11 +479,11 @@ namespace RTCV.UI
                     // COPY FROM JUST CORRUPT
                     AllSpec.CorruptCoreSpec.Update(VSPEC.STEP_RUNBEFORE, true);
 
-                    SyncObjectSingleton.FormExecute(() =>
+                    SyncObjectSingleton.FormExecute(async () =>
                     {
                         bool isload = S.GET<GlitchHarvesterBlastForm>().loadBeforeOperation;
                         S.GET<GlitchHarvesterBlastForm>().loadBeforeOperation = false;
-                        S.GET<GlitchHarvesterBlastForm>().Corrupt(null, null);
+                        await Task.Run(() => S.GET<GlitchHarvesterBlastForm>().Corrupt(null, null));
                         S.GET<GlitchHarvesterBlastForm>().loadBeforeOperation = isload;
                     });
                     //--------------------------------------
@@ -507,7 +508,7 @@ namespace RTCV.UI
 
                 case "Reload Corruption":
 
-                    SyncObjectSingleton.FormExecute(() =>
+                    SyncObjectSingleton.FormExecute(async () =>
                     {
                         var sh = S.GET<StashHistoryForm>();
                         var sm = S.GET<StockpileManagerForm>();
@@ -524,7 +525,7 @@ namespace RTCV.UI
 
                             if (rows.Count > 1)
                             {
-                                ghb.Corrupt(null, null);
+                                await Task.Run(() => ghb.Corrupt(null, null));
                             }
                             else
                             {

--- a/Source/Frontend/UI/VanguardImplementation.cs
+++ b/Source/Frontend/UI/VanguardImplementation.cs
@@ -401,14 +401,6 @@ namespace RTCV.UI
                     //Configure the UI based on the vanguard spec
                     UICore.ConfigureUIFromVanguardSpec();
 
-                    //Pull any lists from the vanguard implementation
-                    if (RtcCore.EmuDir != null)
-                    {
-                        UICore.LoadLists(Path.Combine(RtcCore.EmuDir, "LISTS"));
-                    }
-
-                    UICore.LoadLists(RtcCore.ListsDir);
-
                     Panel sidebar = coreForm.pnSideBar;
                     foreach (Control c in sidebar.Controls)
                     {

--- a/Source/Frontend/UI/VanguardImplementation.cs
+++ b/Source/Frontend/UI/VanguardImplementation.cs
@@ -23,6 +23,7 @@ namespace RTCV.UI
         public static bool isSwapping = false;
         public static TaskCompletionSource<bool> finishedClosing;
         public static TaskCompletionSource<bool> finishedSwapping;
+        public static int timeout = 20;
 
         public static void StartServer()
         {
@@ -182,8 +183,6 @@ namespace RTCV.UI
                 return;
             }
         }
-
-        private static double timeout = 10.0;
 
         private static void SwapTimeout(CanvasForm form)
         {

--- a/Source/Frontend/UI/VanguardImplementation.cs
+++ b/Source/Frontend/UI/VanguardImplementation.cs
@@ -167,7 +167,7 @@ namespace RTCV.UI
                         {
                             var newEmu = (string)(advancedMessage.objectValue as object[])[0];
 
-                            bool result = await Task.Run(() => SwapImplementation(newEmu));
+                            bool result = await SwapImplementation(newEmu);
 
                             e.setReturnValue(result);
                         }

--- a/Source/Frontend/UI/VanguardImplementation.cs
+++ b/Source/Frontend/UI/VanguardImplementation.cs
@@ -21,8 +21,8 @@ namespace RTCV.UI
         private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 
         public static bool isSwapping = false;
-        public static bool finishedClosing = false;
-        public static bool finishedSwapping = false;
+        public static TaskCompletionSource<bool> finishedClosing;
+        public static TaskCompletionSource<bool> finishedSwapping;
 
         public static void StartServer()
         {
@@ -48,7 +48,7 @@ namespace RTCV.UI
             connector?.Kill();
         }
 
-        private static void OnMessageReceived(object sender, NetCoreEventArgs e)
+        private static async void OnMessageReceived(object sender, NetCoreEventArgs e)
         {
             try
             {
@@ -62,7 +62,8 @@ namespace RTCV.UI
                         break;
                     case Remote.AllSpecSent:
                         AllSpecSent();
-                        VanguardImplementation.finishedSwapping = true;
+                        if (isSwapping)
+                            VanguardImplementation.finishedSwapping.TrySetResult(true);
                         break;
                     case Remote.PushVanguardSpecUpdate:
                         PushVanguardSpecUpdate(advancedMessage, ref e);
@@ -163,8 +164,10 @@ namespace RTCV.UI
                     case Remote.SwapImplementation:
                         {
                             var newEmu = (string)(advancedMessage.objectValue as object[])[0];
-                            var form = (ComponentForm)(advancedMessage.objectValue as object[])[1] ?? S.GET<GeneralParametersForm>();
-                            e.setReturnValue(SwapImplementation(newEmu, form));
+
+                            bool result = await Task.Run(() => SwapImplementation(newEmu));
+
+                            e.setReturnValue(result);
                         }
                         break;
                 }
@@ -181,83 +184,68 @@ namespace RTCV.UI
         }
 
         private static double timeout = 10.0;
-        private static double time_elapsed = 0.0;
-        private static System.Timers.Timer swapTimeout = new System.Timers.Timer
+
+        private static void SwapTimeout(CanvasForm form)
         {
-            AutoReset = false,
-            Interval = 100
-        };
-        private static event ElapsedEventHandler timeoutHandler;
+            Task.Run(() => MessageBox.Show($"Failed to swap emulators."));
 
-        private static void OnSwapTimeout(object source, ElapsedEventArgs e, ComponentForm form)
-        {
-            time_elapsed += 0.1;
-            logger.Trace(time_elapsed);
-            if (time_elapsed >= timeout)
-            {
-                Task.Run(() => MessageBox.Show($"Failed to swap emulators."));
+            SyncObjectSingleton.FormExecute(() => { form.CloseSubForm(); });
+            logger.Trace("Unlocking Interface");
+            SyncObjectSingleton.FormExecute(() => { UICore.UnlockInterface(); });
+            logger.Trace("Load cancelled");
 
-                form.ParentCanvas?.CloseSubForm();
-                logger.Trace("Unlocking Interface");
-                UICore.UnlockInterface();
-                logger.Trace("Load cancelled");
-
-                AutoKillSwitch.Enabled = true;
-                VanguardImplementation.isSwapping = false;
-                VanguardImplementation.finishedClosing = false;
-                VanguardImplementation.finishedSwapping = false;
-                swapTimeout.Stop();
-                swapTimeout.Elapsed -= timeoutHandler;
-                return;
-            }
-            else
-            {
-                swapTimeout.Stop();
-                swapTimeout.Start();
-            }
+            AutoKillSwitch.Enabled = true;
+            VanguardImplementation.isSwapping = false;
+            return;
         }
-
-        private static bool SwapImplementation(string newEmu, ComponentForm form)
+        
+        public static async Task<bool> SwapImplementation(string newEmu)
         {
-            VanguardImplementation.isSwapping = true;
-            VanguardImplementation.finishedClosing = false;
-            VanguardImplementation.finishedSwapping = false;
+            // Get the currently active form for displaying the loading bar. If there isn't any (a.k.a we're loading an implementation from the launcher),
+            // then find the first visible CanvasForm and display it on that instead.
+            var openForms = Application.OpenForms.Cast<Form>();
+            var activeForm = openForms.Where(form => form == Form.ActiveForm).FirstOrDefault() as CanvasForm;
+            var windowSelect = activeForm ?? openForms.Where(form => form is CanvasForm && form.Visible).First() as CanvasForm;
 
-            timeoutHandler ??= (sender, e) => OnSwapTimeout(sender, e, form);
+            Task completedTask = null;
+            var timeoutTask = Task.Delay(TimeSpan.FromSeconds(timeout));
 
-            time_elapsed = 0.0;
-            swapTimeout.Elapsed += timeoutHandler;
-            swapTimeout.Start();
+            isSwapping = true;
+            finishedClosing = new TaskCompletionSource<bool>(false);
+            finishedSwapping = new TaskCompletionSource<bool>(false);
 
             logger.Trace("different emulator found, switching");
 
             AutoKillSwitch.Enabled = false;
-                
-            var focusCoreForm = form.ParentCanvas.Name == "CoreForm" ? true : false;
+
+            // If we were focused on the glitch harvester, don't focus the core form
             logger.Trace("Blocking UI");
-            UICore.LockInterface(focusCoreForm, true);
+            bool focusCoreForm = windowSelect.Text == "Glitch Harvester" ? false : true;
+            SyncObjectSingleton.FormExecute(() => { UICore.LockInterface(focusCoreForm, true); });
             logger.Trace("UI Blocked");
 
             string oldEmuDir = CorruptCore.RtcCore.EmuDir;
-            var newEmuDir = Path.Combine(Path.Combine(new DirectoryInfo(RtcCore.RtcDir).Parent.Parent.FullName, StockpileManagerUISide.CurrentStashkey.EmuVer));
+            var newEmuDir = Path.Combine(Path.Combine(new DirectoryInfo(RtcCore.RtcDir).Parent.Parent.FullName, newEmu));
             CorruptCore.RtcCore.EmuDir = newEmuDir;
 
-            // Load the save progress form
+            // Load the progress form
             S.GET<SaveProgressForm>().Dock = DockStyle.Fill;
-            form.ParentCanvas?.OpenSubForm(S.GET<SaveProgressForm>());
+            SyncObjectSingleton.FormExecute(() => { windowSelect.OpenSubForm(S.GET<SaveProgressForm>()); });
             RtcCore.OnProgressBarUpdate(null, new ProgressBarEventArgs($"Switching from " + new DirectoryInfo(oldEmuDir).Name +
-                                            " to " + StockpileManagerUISide.CurrentStashkey.EmuVer, 0));
+                                            " to " + newEmu, 0));
 
             LocalNetCoreRouter.Route(NetCore.Endpoints.Vanguard, NetCore.Commands.Remote.EventCloseEmulator);
-            while (!VanguardImplementation.finishedClosing)
-            {
-                if (!swapTimeout.Enabled)
-                    return false;
 
-                Application.DoEvents();
-                Thread.Sleep(100);
+            // Wait until the UI thread has confirmed the emulator has finished closing
+            // This will be when RTC has lost the TCP connection with the emulator
+            completedTask = await Task.WhenAny(finishedClosing.Task, timeoutTask).ConfigureAwait(false);
+            if (completedTask == timeoutTask)
+            {
+                SwapTimeout(windowSelect);
+                return false;
             }
 
+            // Open the new emulator
             var info = new System.Diagnostics.ProcessStartInfo()
             {
                 UseShellExecute = false,
@@ -269,7 +257,7 @@ namespace RTCV.UI
             {
                 MessageBox.Show($"Couldn't find {info.FileName}! Killswitch will not work.");
 
-                form.ParentCanvas?.CloseSubForm();
+                SyncObjectSingleton.FormExecute(() => { windowSelect.CloseSubForm(); });
                 logger.Trace("Unlocking Interface");
                 UICore.UnlockInterface();
                 logger.Trace("Load cancelled");
@@ -280,28 +268,37 @@ namespace RTCV.UI
                 return false;
             }
 
-            // Restart the timeout timer
-            swapTimeout.Stop();
-            swapTimeout.Start();
-
             logger.Trace("Starting the new process");
-            RtcCore.OnProgressBarUpdate(null, new ProgressBarEventArgs($"Starting " + StockpileManagerUISide.CurrentStashkey.EmuVer, 50));
+            RtcCore.OnProgressBarUpdate(null, new ProgressBarEventArgs($"Starting " + newEmu, 50));
 
             System.Diagnostics.Process.Start(info);
 
-            // Once AllSpecSent() is finished, we've successfully finished swapping to the new emulator
-            while (!VanguardImplementation.finishedSwapping)
+
+            // Wait until the UI thread has confirmed the emulator has finished opening
+            // This will be once AllSpecSent() has finished
+            completedTask = await Task.WhenAny(finishedSwapping.Task, timeoutTask).ConfigureAwait(false);
+            if (completedTask == timeoutTask)
             {
-                Application.DoEvents();
-                Thread.Sleep(100);
+                SwapTimeout(windowSelect);
+                return false;
             }
+
+            // We need to make sure to send the name to the connection status form again since we couldn't get it before reconnecting
+            SyncObjectSingleton.FormExecute(() =>
+            {
+                S.GET<ConnectionStatusForm>().lbConnectionStatus.Text =
+                    $"Connected to {(string)AllSpec.VanguardSpec?[VSPEC.NAME] ?? "Vanguard"}";
+            });
 
             RtcCore.OnProgressBarUpdate(null, new ProgressBarEventArgs($"Loading stockpile entry", 100));
 
-            swapTimeout.Stop();
-            swapTimeout.Elapsed -= timeoutHandler;
-            form.ParentCanvas?.CloseSubForm();
+            SyncObjectSingleton.FormExecute(() => { windowSelect.CloseSubForm(); });
             VanguardImplementation.isSwapping = false;
+
+            logger.Trace("Unlocking UI");
+            SyncObjectSingleton.FormExecute(() => { UICore.UnlockInterface(); });
+            logger.Trace("UI Unlocked");
+
             return true;
         }
 

--- a/Source/Frontend/UI/VanguardImplementation.cs
+++ b/Source/Frontend/UI/VanguardImplementation.cs
@@ -241,6 +241,33 @@ namespace RTCV.UI
 
                     DefaultGrids.glitchHarvester.LoadToNewWindow("Glitch Harvester", true);
                 }
+                else if (UICore.isSwapping)
+                {
+                    lastVanguardClient = (string)AllSpec.VanguardSpec?[VSPEC.NAME] ?? "VANGUARD";
+
+                    //Configure the UI based on the vanguard spec
+                    UICore.ConfigureUIFromVanguardSpec();
+
+                    //Pull any lists from the vanguard implementation
+                    if (RtcCore.EmuDir != null)
+                    {
+                        UICore.LoadLists(Path.Combine(RtcCore.EmuDir, "LISTS"));
+                    }
+
+                    UICore.LoadLists(RtcCore.ListsDir);
+
+                    Panel sidebar = coreForm.pnSideBar;
+                    foreach (Control c in sidebar.Controls)
+                    {
+                        if (c is Button b)
+                        {
+                            if (!b.Text.Contains("Test") && b.ForeColor != Color.OrangeRed)
+                            {
+                                b.Visible = true;
+                            }
+                        }
+                    }
+                }
                 else
                 {
                     LocalNetCoreRouter.Route(Endpoints.CorruptCore, Remote.LoadPlugins, true);

--- a/Source/Frontend/UI/VanguardImplementation.cs
+++ b/Source/Frontend/UI/VanguardImplementation.cs
@@ -22,9 +22,6 @@ namespace RTCV.UI
         private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 
         public static bool isSwapping = false;
-        public static TaskCompletionSource<bool> finishedClosing;
-        public static TaskCompletionSource<bool> finishedSwapping;
-        public static int timeout = 20;
 
         public static void StartServer()
         {
@@ -65,7 +62,7 @@ namespace RTCV.UI
                     case Remote.AllSpecSent:
                         AllSpecSent();
                         if (isSwapping)
-                            VanguardImplementation.finishedSwapping.TrySetResult(true);
+                            StockpileManagerUISide.finishedSwapping.TrySetResult(true);
                         break;
                     case Remote.PushVanguardSpecUpdate:
                         PushVanguardSpecUpdate(advancedMessage, ref e);
@@ -165,7 +162,7 @@ namespace RTCV.UI
                         break;
                     case Remote.SwapImplementation:
                         {
-                            var newEmu = (string)(advancedMessage.objectValue as object[])[0];
+                            var newEmu = (string)(advancedMessage.objectValue);
 
                             bool result = await SwapImplementation(newEmu);
 
@@ -208,11 +205,11 @@ namespace RTCV.UI
             var windowSelect = activeForm ?? openForms.Where(form => form is CanvasForm && form.Visible).First() as CanvasForm;
 
             Task completedTask = null;
-            var timeoutTask = Task.Delay(TimeSpan.FromSeconds(timeout));
+            
 
             isSwapping = true;
-            finishedClosing = new TaskCompletionSource<bool>(false);
-            finishedSwapping = new TaskCompletionSource<bool>(false);
+            StockpileManagerUISide.finishedClosing = new TaskCompletionSource<bool>(false);
+            StockpileManagerUISide.finishedSwapping = new TaskCompletionSource<bool>(false);
 
             logger.Trace("different emulator found, switching");
 
@@ -239,8 +236,8 @@ namespace RTCV.UI
 
             // Wait until the UI thread has confirmed the emulator has finished closing
             // This will be when RTC has lost the TCP connection with the emulator
-            completedTask = await Task.WhenAny(finishedClosing.Task, timeoutTask).ConfigureAwait(false);
-            if (completedTask == timeoutTask)
+            completedTask = await Task.WhenAny(StockpileManagerUISide.finishedClosing.Task, StockpileManagerUISide.timeoutTask).ConfigureAwait(false);
+            if (completedTask == StockpileManagerUISide.timeoutTask)
             {
                 SwapTimeout(windowSelect);
                 return false;
@@ -277,8 +274,8 @@ namespace RTCV.UI
 
             // Wait until the UI thread has confirmed the emulator has finished opening
             // This will be once AllSpecSent() has finished
-            completedTask = await Task.WhenAny(finishedSwapping.Task, timeoutTask).ConfigureAwait(false);
-            if (completedTask == timeoutTask)
+            completedTask = await Task.WhenAny(StockpileManagerUISide.finishedSwapping.Task, StockpileManagerUISide.timeoutTask).ConfigureAwait(false);
+            if (completedTask == StockpileManagerUISide.timeoutTask)
             {
                 SwapTimeout(windowSelect);
                 return false;

--- a/Source/Frontend/UI/VanguardImplementation.cs
+++ b/Source/Frontend/UI/VanguardImplementation.cs
@@ -13,6 +13,7 @@ namespace RTCV.UI
     using System.Threading.Tasks;
     using System.Threading;
     using System.Timers;
+    using System.Collections.Generic;
 
     public static class VanguardImplementation
     {
@@ -217,9 +218,10 @@ namespace RTCV.UI
 
             AutoKillSwitch.Enabled = false;
 
-            // If we were focused on the glitch harvester, don't focus the core form
+            // If we were focused on anything other than the core form (aka we're swapping emulators from the launcher), don't focus it
             logger.Trace("Blocking UI");
-            bool focusCoreForm = windowSelect.Text == "Glitch Harvester" ? false : true;
+            var stayFocusedForms = new List<string> { "Glitch Harvester", "Blast Editor", "Blast Generator" };
+            bool focusCoreForm = stayFocusedForms.Contains(windowSelect.Text, StringComparer.OrdinalIgnoreCase) ? false : true;
             SyncObjectSingleton.FormExecute(() => { UICore.LockInterface(focusCoreForm, true); });
             logger.Trace("UI Blocked");
 

--- a/Source/Frontend/UI/VanguardImplementation.cs
+++ b/Source/Frontend/UI/VanguardImplementation.cs
@@ -290,7 +290,7 @@ namespace RTCV.UI
 
                 if (!RtcCore.Attached)
                 {
-                    AutoKillSwitch.Enabled = true;
+                    //AutoKillSwitch.Enabled = true;
                 }
 
                 //Restart game protection

--- a/Source/Frontend/UI/VanguardImplementation.cs
+++ b/Source/Frontend/UI/VanguardImplementation.cs
@@ -12,12 +12,17 @@ namespace RTCV.UI
     using RTCV.NetCore.Commands;
     using System.Threading.Tasks;
     using System.Threading;
+    using System.Timers;
 
     public static class VanguardImplementation
     {
         internal static UIConnector connector = null;
         private static string lastVanguardClient = "";
         private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+
+        public static bool isSwapping = false;
+        public static bool finishedClosing = false;
+        public static bool finishedSwapping = false;
 
         public static void StartServer()
         {
@@ -57,7 +62,7 @@ namespace RTCV.UI
                         break;
                     case Remote.AllSpecSent:
                         AllSpecSent();
-                        UICore.finishedSwapping = true;
+                        VanguardImplementation.finishedSwapping = true;
                         break;
                     case Remote.PushVanguardSpecUpdate:
                         PushVanguardSpecUpdate(advancedMessage, ref e);
@@ -155,6 +160,13 @@ namespace RTCV.UI
                             UICore.CheckHotkey(hotkey);
                         }
                         break;
+                    case Remote.SwapImplementation:
+                        {
+                            var newEmu = (string)(advancedMessage.objectValue as object[])[0];
+                            var form = (ComponentForm)(advancedMessage.objectValue as object[])[1] ?? S.GET<GeneralParametersForm>();
+                            e.setReturnValue(SwapImplementation(newEmu, form));
+                        }
+                        break;
                 }
             }
             catch (Exception ex)
@@ -166,6 +178,131 @@ namespace RTCV.UI
 
                 return;
             }
+        }
+
+        private static double timeout = 10.0;
+        private static double time_elapsed = 0.0;
+        private static System.Timers.Timer swapTimeout = new System.Timers.Timer
+        {
+            AutoReset = false,
+            Interval = 100
+        };
+        private static event ElapsedEventHandler timeoutHandler;
+
+        private static void OnSwapTimeout(object source, ElapsedEventArgs e, ComponentForm form)
+        {
+            time_elapsed += 0.1;
+            logger.Trace(time_elapsed);
+            if (time_elapsed >= timeout)
+            {
+                Task.Run(() => MessageBox.Show($"Failed to swap emulators."));
+
+                form.ParentCanvas?.CloseSubForm();
+                logger.Trace("Unlocking Interface");
+                UICore.UnlockInterface();
+                logger.Trace("Load cancelled");
+
+                AutoKillSwitch.Enabled = true;
+                VanguardImplementation.isSwapping = false;
+                VanguardImplementation.finishedClosing = false;
+                VanguardImplementation.finishedSwapping = false;
+                swapTimeout.Stop();
+                swapTimeout.Elapsed -= timeoutHandler;
+                return;
+            }
+            else
+            {
+                swapTimeout.Stop();
+                swapTimeout.Start();
+            }
+        }
+
+        private static bool SwapImplementation(string newEmu, ComponentForm form)
+        {
+            VanguardImplementation.isSwapping = true;
+            VanguardImplementation.finishedClosing = false;
+            VanguardImplementation.finishedSwapping = false;
+
+            timeoutHandler ??= (sender, e) => OnSwapTimeout(sender, e, form);
+
+            time_elapsed = 0.0;
+            swapTimeout.Elapsed += timeoutHandler;
+            swapTimeout.Start();
+
+            logger.Trace("different emulator found, switching");
+
+            AutoKillSwitch.Enabled = false;
+                
+            var focusCoreForm = form.ParentCanvas.Name == "CoreForm" ? true : false;
+            logger.Trace("Blocking UI");
+            UICore.LockInterface(focusCoreForm, true);
+            logger.Trace("UI Blocked");
+
+            string oldEmuDir = CorruptCore.RtcCore.EmuDir;
+            var newEmuDir = Path.Combine(Path.Combine(new DirectoryInfo(RtcCore.RtcDir).Parent.Parent.FullName, StockpileManagerUISide.CurrentStashkey.EmuVer));
+            CorruptCore.RtcCore.EmuDir = newEmuDir;
+
+            // Load the save progress form
+            S.GET<SaveProgressForm>().Dock = DockStyle.Fill;
+            form.ParentCanvas?.OpenSubForm(S.GET<SaveProgressForm>());
+            RtcCore.OnProgressBarUpdate(null, new ProgressBarEventArgs($"Switching from " + new DirectoryInfo(oldEmuDir).Name +
+                                            " to " + StockpileManagerUISide.CurrentStashkey.EmuVer, 0));
+
+            LocalNetCoreRouter.Route(NetCore.Endpoints.Vanguard, NetCore.Commands.Remote.EventCloseEmulator);
+            while (!VanguardImplementation.finishedClosing)
+            {
+                if (!swapTimeout.Enabled)
+                    return false;
+
+                Application.DoEvents();
+                Thread.Sleep(100);
+            }
+
+            var info = new System.Diagnostics.ProcessStartInfo()
+            {
+                UseShellExecute = false,
+                WorkingDirectory = newEmuDir,
+                FileName = Path.Combine(newEmuDir, "RESTARTDETACHEDRTC.bat"),
+            };
+
+            if (!File.Exists(info.FileName))
+            {
+                MessageBox.Show($"Couldn't find {info.FileName}! Killswitch will not work.");
+
+                form.ParentCanvas?.CloseSubForm();
+                logger.Trace("Unlocking Interface");
+                UICore.UnlockInterface();
+                logger.Trace("Load cancelled");
+
+                AutoKillSwitch.Enabled = true;
+                VanguardImplementation.isSwapping = false;
+
+                return false;
+            }
+
+            // Restart the timeout timer
+            swapTimeout.Stop();
+            swapTimeout.Start();
+
+            logger.Trace("Starting the new process");
+            RtcCore.OnProgressBarUpdate(null, new ProgressBarEventArgs($"Starting " + StockpileManagerUISide.CurrentStashkey.EmuVer, 50));
+
+            System.Diagnostics.Process.Start(info);
+
+            // Once AllSpecSent() is finished, we've successfully finished swapping to the new emulator
+            while (!VanguardImplementation.finishedSwapping)
+            {
+                Application.DoEvents();
+                Thread.Sleep(100);
+            }
+
+            RtcCore.OnProgressBarUpdate(null, new ProgressBarEventArgs($"Loading stockpile entry", 100));
+
+            swapTimeout.Stop();
+            swapTimeout.Elapsed -= timeoutHandler;
+            form.ParentCanvas?.CloseSubForm();
+            VanguardImplementation.isSwapping = false;
+            return true;
         }
 
         private static void PushVanguardSpec(NetCoreAdvancedMessage advancedMessage, ref NetCoreEventArgs e)
@@ -242,7 +379,7 @@ namespace RTCV.UI
 
                     DefaultGrids.glitchHarvester.LoadToNewWindow("Glitch Harvester", true);
                 }
-                else if (UICore.isSwapping)
+                else if (VanguardImplementation.isSwapping)
                 {
                     lastVanguardClient = (string)AllSpec.VanguardSpec?[VSPEC.NAME] ?? "VANGUARD";
 

--- a/Source/Frontend/UI/VanguardImplementation.cs
+++ b/Source/Frontend/UI/VanguardImplementation.cs
@@ -398,6 +398,9 @@ namespace RTCV.UI
                 {
                     lastVanguardClient = (string)AllSpec.VanguardSpec?[VSPEC.NAME] ?? "VANGUARD";
 
+                    //make sure the other side reloads the plugins
+                    LocalNetCoreRouter.Route(Endpoints.CorruptCore, Remote.LoadPlugins, true);
+
                     //Configure the UI based on the vanguard spec
                     UICore.ConfigureUIFromVanguardSpec();
 

--- a/Source/Frontend/UI/VanguardImplementation.cs
+++ b/Source/Frontend/UI/VanguardImplementation.cs
@@ -57,6 +57,7 @@ namespace RTCV.UI
                         break;
                     case Remote.AllSpecSent:
                         AllSpecSent();
+                        UICore.finishedSwapping = true;
                         break;
                     case Remote.PushVanguardSpecUpdate:
                         PushVanguardSpecUpdate(advancedMessage, ref e);
@@ -274,11 +275,12 @@ namespace RTCV.UI
                     //make sure the other side reloads the plugins
 
                     var clientName = (string)AllSpec.VanguardSpec?[VSPEC.NAME] ?? "VANGUARD";
-                    if (clientName != lastVanguardClient)
+                    // Disabled with the addition of cross-emulator stockpiles
+                    /*if (clientName != lastVanguardClient)
                     {
                         MessageBox.Show($"Error: Found {clientName} when previously connected to {lastVanguardClient}.\nPlease restart the RTC to swap clients.");
                         return;
-                    }
+                    }*/
 
                     //Push the VMDs since we store them out of spec
                     var vmdProtos = MemoryDomains.VmdPool.Values.Select(x => x.Proto).ToArray();

--- a/Source/Frontend/UI/VanguardImplementation.cs
+++ b/Source/Frontend/UI/VanguardImplementation.cs
@@ -22,6 +22,7 @@ namespace RTCV.UI
         private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 
         public static bool isSwapping = false;
+        public static CanvasForm windowSelect = null;
 
         public static void StartServer()
         {
@@ -169,6 +170,16 @@ namespace RTCV.UI
                             e.setReturnValue(result);
                         }
                         break;
+                    case Remote.UnlockInterface:
+                        {
+                            if (windowSelect != null)
+                                SyncObjectSingleton.FormExecute(() => { windowSelect.CloseSubForm(); });
+
+                            logger.Trace("Unlocking UI");
+                            SyncObjectSingleton.FormExecute(() => { UICore.UnlockInterface(); });
+                            logger.Trace("UI Unlocked");
+                        }
+                        break;
                 }
             }
             catch (Exception ex)
@@ -204,7 +215,7 @@ namespace RTCV.UI
             // then find the first visible CanvasForm and display it on that instead.
             var openForms = Application.OpenForms.Cast<Form>();
             var activeForm = openForms.Where(form => form == Form.ActiveForm).FirstOrDefault() as CanvasForm;
-            var windowSelect = activeForm ?? openForms.Where(form => form is CanvasForm && form.Visible).First() as CanvasForm;
+            windowSelect = activeForm ?? openForms.Where(form => form is CanvasForm && form.Visible).First() as CanvasForm;
 
             Task completedTask = null;
             CancellationTokenSource cts = new CancellationTokenSource();
@@ -294,7 +305,7 @@ namespace RTCV.UI
                     $"Connected to {(string)AllSpec.VanguardSpec?[VSPEC.NAME] ?? "Vanguard"}";
             });
 
-            RtcCore.OnProgressBarUpdate(null, new ProgressBarEventArgs($"Loading stockpile entry", 100));
+            RtcCore.OnProgressBarUpdate(null, new ProgressBarEventArgs($"Loading game", 100));
 
             VanguardImplementation.isSwapping = false;
             cts.Cancel();

--- a/Source/Frontend/UI/VanguardImplementation.cs
+++ b/Source/Frontend/UI/VanguardImplementation.cs
@@ -184,7 +184,9 @@ namespace RTCV.UI
 
         private static void SwapTimeout(CanvasForm form)
         {
-            Task.Run(() => MessageBox.Show($"Failed to swap emulators."));
+            Task.Run(() => MessageBox.Show($"Failed to swap emulators. Please save your work, then close and reopen RTC. If you are able to reproduce this issue," +
+                $"poke the RTC devs for help (Discord is in the launcher).", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error,
+                                MessageBoxDefaultButton.Button1, MessageBoxOptions.DefaultDesktopOnly));
 
             SyncObjectSingleton.FormExecute(() => { form.CloseSubForm(); });
             logger.Trace("Unlocking Interface");
@@ -205,8 +207,11 @@ namespace RTCV.UI
             var windowSelect = activeForm ?? openForms.Where(form => form is CanvasForm && form.Visible).First() as CanvasForm;
 
             Task completedTask = null;
-            if (StockpileManagerUISide.timeoutTask == null || StockpileManagerUISide.timeoutTask.IsCompleted.Equals(true))
-                StockpileManagerUISide.timeoutTask = Task.Delay(TimeSpan.FromSeconds(StockpileManagerUISide.timeout));
+            CancellationTokenSource cts = new CancellationTokenSource();
+            if (StockpileManagerUISide.timeoutTask == null || StockpileManagerUISide.timeoutTask.IsCanceled)
+            {
+                StockpileManagerUISide.timeoutTask = Task.Delay(TimeSpan.FromSeconds(StockpileManagerUISide.timeout), cts.Token);
+            }
 
             isSwapping = true;
             StockpileManagerUISide.finishedClosing = new TaskCompletionSource<bool>(false);
@@ -238,7 +243,7 @@ namespace RTCV.UI
             // Wait until the UI thread has confirmed the emulator has finished closing
             // This will be when RTC has lost the TCP connection with the emulator
             completedTask = await Task.WhenAny(StockpileManagerUISide.finishedClosing.Task, StockpileManagerUISide.timeoutTask).ConfigureAwait(false);
-            if (completedTask == StockpileManagerUISide.timeoutTask)
+            if (completedTask == StockpileManagerUISide.timeoutTask && !completedTask.IsCanceled)
             {
                 SwapTimeout(windowSelect);
                 return false;
@@ -276,7 +281,7 @@ namespace RTCV.UI
             // Wait until the UI thread has confirmed the emulator has finished opening
             // This will be once AllSpecSent() has finished
             completedTask = await Task.WhenAny(StockpileManagerUISide.finishedSwapping.Task, StockpileManagerUISide.timeoutTask).ConfigureAwait(false);
-            if (completedTask == StockpileManagerUISide.timeoutTask)
+            if (completedTask == StockpileManagerUISide.timeoutTask && !completedTask.IsCanceled)
             {
                 SwapTimeout(windowSelect);
                 return false;
@@ -291,13 +296,8 @@ namespace RTCV.UI
 
             RtcCore.OnProgressBarUpdate(null, new ProgressBarEventArgs($"Loading stockpile entry", 100));
 
-            SyncObjectSingleton.FormExecute(() => { windowSelect.CloseSubForm(); });
             VanguardImplementation.isSwapping = false;
-
-            logger.Trace("Unlocking UI");
-            SyncObjectSingleton.FormExecute(() => { UICore.UnlockInterface(); });
-            logger.Trace("UI Unlocked");
-
+            cts.Cancel();
             return true;
         }
 

--- a/Source/Frontend/UI/VanguardImplementation.cs
+++ b/Source/Frontend/UI/VanguardImplementation.cs
@@ -163,9 +163,13 @@ namespace RTCV.UI
                         break;
                     case Remote.SwapImplementation:
                         {
-                            var newEmu = (string)(advancedMessage.objectValue as object[])[0];
+                            var args = (object[])(advancedMessage.objectValue as object[]);
+                            var newEmu = (string)args[0];
+                            var unlockAfterSwap = false;
+                            if (args.Length > 1)
+                                unlockAfterSwap = (bool)args[1];
 
-                            bool result = await SwapImplementation(newEmu);
+                            bool result = await SwapImplementation(newEmu, unlockAfterSwap);
 
                             e.setReturnValue(result);
                         }
@@ -209,7 +213,7 @@ namespace RTCV.UI
             return;
         }
         
-        public static async Task<bool> SwapImplementation(string newEmu)
+        public static async Task<bool> SwapImplementation(string newEmu, bool unlockAfterSwap = false)
         {
             // Get the currently active form for displaying the loading bar. If there isn't any (a.k.a we're loading an implementation from the launcher),
             // then find the first visible CanvasForm and display it on that instead.
@@ -309,6 +313,10 @@ namespace RTCV.UI
 
             VanguardImplementation.isSwapping = false;
             cts.Cancel();
+
+            if (unlockAfterSwap)
+                LocalNetCoreRouter.Route(Endpoints.UI, NetCore.Commands.Remote.UnlockInterface, true);
+
             return true;
         }
 

--- a/Source/Frontend/UI/VanguardImplementation.cs
+++ b/Source/Frontend/UI/VanguardImplementation.cs
@@ -162,7 +162,7 @@ namespace RTCV.UI
                         break;
                     case Remote.SwapImplementation:
                         {
-                            var newEmu = (string)(advancedMessage.objectValue);
+                            var newEmu = (string)(advancedMessage.objectValue as object[])[0];
 
                             bool result = await SwapImplementation(newEmu);
 
@@ -205,7 +205,8 @@ namespace RTCV.UI
             var windowSelect = activeForm ?? openForms.Where(form => form is CanvasForm && form.Visible).First() as CanvasForm;
 
             Task completedTask = null;
-            
+            if (StockpileManagerUISide.timeoutTask == null || StockpileManagerUISide.timeoutTask.IsCompleted.Equals(true))
+                StockpileManagerUISide.timeoutTask = Task.Delay(TimeSpan.FromSeconds(StockpileManagerUISide.timeout));
 
             isSwapping = true;
             StockpileManagerUISide.finishedClosing = new TaskCompletionSource<bool>(false);

--- a/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
+++ b/Source/Libraries/CorruptCore/CorruptCoreConnector.cs
@@ -195,7 +195,7 @@ namespace RTCV.CorruptCore
 
                     case Remote.DomainPeekByte:
                         {
-                            //ObjectValue -­> Object[] -­> string DomainName, long Address
+                            //ObjectValue -ï¿½> Object[] -ï¿½> string DomainName, long Address
                             //returns: byte Value
 
                             var obj = advancedMessage.objectValue as object[];
@@ -208,7 +208,7 @@ namespace RTCV.CorruptCore
                         }
                     case Remote.DomainPokeByte:
                         {
-                            //ObjectValue -­> Object[] -­> string DomainName, long Address, byte Value
+                            //ObjectValue -ï¿½> Object[] -ï¿½> string DomainName, long Address, byte Value
                             //no return
 
                             var obj = advancedMessage.objectValue as object[];
@@ -222,7 +222,7 @@ namespace RTCV.CorruptCore
                         }
                     case Remote.DomainPeekBytes:
                         {
-                            //ObjectValue -­> Object[] -­> string DomainName, long StartAddress, long EndAddress, bool raw
+                            //ObjectValue -ï¿½> Object[] -ï¿½> string DomainName, long StartAddress, long EndAddress, bool raw
                             //returns: byte[] Value
 
                             var obj = advancedMessage.objectValue as object[];
@@ -237,7 +237,7 @@ namespace RTCV.CorruptCore
                         }
                     case Remote.DomainPokeBytes:
                         {
-                            //ObjectValue -­> Object[] -­> string DomainName, long Address, byte[] Value, bool raw
+                            //ObjectValue -ï¿½> Object[] -ï¿½> string DomainName, long Address, byte[] Value, bool raw
                             //no return
 
                             var obj = advancedMessage.objectValue as object[];
@@ -253,7 +253,7 @@ namespace RTCV.CorruptCore
 
                     case Remote.RerollBlastLayer:
                         {
-                            //ObjectValue -­> Object -­> BlastLayer bl
+                            //ObjectValue -ï¿½> Object -ï¿½> BlastLayer bl
                             //returns BlastLayer
 
                             var bl = (BlastLayer)advancedMessage.objectValue;

--- a/Source/Libraries/CorruptCore/StashKey.cs
+++ b/Source/Libraries/CorruptCore/StashKey.cs
@@ -34,6 +34,7 @@ namespace RTCV.CorruptCore
         public string SystemName { get; set; }
         public string SystemDeepName { get; set; }
         public string SystemCore { get; set; }
+        public string EmuVer { get; set; }
         public List<string> SelectedDomains { get; set; } = new List<string>();
         public string GameName { get; set; }
         public string SyncSettings { get; set; }

--- a/Source/Libraries/CorruptCore/StashKey.cs
+++ b/Source/Libraries/CorruptCore/StashKey.cs
@@ -5,6 +5,7 @@ namespace RTCV.CorruptCore
     using System.Data;
     using System.IO;
     using System.Linq;
+    using System.Threading.Tasks;
     using System.Windows.Forms;
     using Ceras;
     using Newtonsoft.Json;
@@ -106,19 +107,19 @@ namespace RTCV.CorruptCore
         /// <summary>
         /// Can be called from UI Side
         /// </summary>
-        public bool Run()
+        public async Task<bool> Run()
         {
             StockpileManagerUISide.CurrentStashkey = this;
-            return StockpileManagerUISide.ApplyStashkey(this);
+            return await StockpileManagerUISide.ApplyStashkey(this);
         }
 
         /// <summary>
         /// Can be called from UI Side
         /// </summary>
-        public void RunOriginal()
+        public async Task RunOriginal()
         {
             StockpileManagerUISide.CurrentStashkey = this;
-            StockpileManagerUISide.OriginalFromStashkey(this);
+            await StockpileManagerUISide.OriginalFromStashkey(this);
         }
 
         public byte[] EmbedState()

--- a/Source/Libraries/CorruptCore/StashKey.cs
+++ b/Source/Libraries/CorruptCore/StashKey.cs
@@ -57,7 +57,8 @@ namespace RTCV.CorruptCore
             var key = RtcCore.GetRandomKey();
             string parentkey = null;
             BlastLayer blastlayer = new BlastLayer();
-            StashKeyConstructor(key, parentkey, blastlayer);
+            bool useEmuVer = false;
+            StashKeyConstructor(key, parentkey, blastlayer, useEmuVer);
         }
 
         public StashKey(string key, string parentkey, BlastLayer blastlayer)
@@ -65,7 +66,7 @@ namespace RTCV.CorruptCore
             StashKeyConstructor(key, parentkey, blastlayer);
         }
 
-        private void StashKeyConstructor(string key, string parentkey, BlastLayer blastlayer)
+        private void StashKeyConstructor(string key, string parentkey, BlastLayer blastlayer, bool useEmuVer = true)
         {
             Key = key;
             ParentKey = parentkey;
@@ -77,7 +78,7 @@ namespace RTCV.CorruptCore
             GameName = (string)AllSpec.VanguardSpec?[VSPEC.GAMENAME] ?? "ERROR";
             SyncSettings = (string)AllSpec.VanguardSpec?[VSPEC.SYNCSETTINGS] ?? "";
 
-            var dirCheck = !string.IsNullOrEmpty((string)AllSpec.VanguardSpec?[VSPEC.EMUDIR]);
+            var dirCheck = useEmuVer ? !string.IsNullOrEmpty((string)AllSpec.VanguardSpec?[VSPEC.EMUDIR]) : false;
             EmuVer = dirCheck ? new DirectoryInfo((string)AllSpec.VanguardSpec?[VSPEC.EMUDIR]).Name.ToUpper() : "";
 
             this.SelectedDomains = ((string[])AllSpec.UISpec[UISPEC.SELECTEDDOMAINS]).ToList();

--- a/Source/Libraries/CorruptCore/StashKey.cs
+++ b/Source/Libraries/CorruptCore/StashKey.cs
@@ -78,7 +78,7 @@ namespace RTCV.CorruptCore
             SyncSettings = (string)AllSpec.VanguardSpec?[VSPEC.SYNCSETTINGS] ?? "";
 
             var dirCheck = !string.IsNullOrEmpty((string)AllSpec.VanguardSpec?[VSPEC.EMUDIR]);
-            EmuVer = dirCheck  ? new DirectoryInfo((string)AllSpec.VanguardSpec?[VSPEC.EMUDIR]).Name : "";
+            EmuVer = dirCheck ? new DirectoryInfo((string)AllSpec.VanguardSpec?[VSPEC.EMUDIR]).Name.ToUpper() : "";
 
             this.SelectedDomains = ((string[])AllSpec.UISpec[UISPEC.SELECTEDDOMAINS]).ToList();
         }

--- a/Source/Libraries/CorruptCore/StashKey.cs
+++ b/Source/Libraries/CorruptCore/StashKey.cs
@@ -76,7 +76,9 @@ namespace RTCV.CorruptCore
             SystemCore = (string)AllSpec.VanguardSpec?[VSPEC.SYSTEMCORE] ?? "ERROR";
             GameName = (string)AllSpec.VanguardSpec?[VSPEC.GAMENAME] ?? "ERROR";
             SyncSettings = (string)AllSpec.VanguardSpec?[VSPEC.SYNCSETTINGS] ?? "";
-            EmuVer = (string)new DirectoryInfo((string)AllSpec.VanguardSpec[VSPEC.EMUDIR]).Name ?? "";
+
+            var dirCheck = !string.IsNullOrEmpty((string)AllSpec.VanguardSpec?[VSPEC.EMUDIR]);
+            EmuVer = dirCheck  ? new DirectoryInfo((string)AllSpec.VanguardSpec?[VSPEC.EMUDIR]).Name : "";
 
             this.SelectedDomains = ((string[])AllSpec.UISpec[UISPEC.SELECTEDDOMAINS]).ToList();
         }

--- a/Source/Libraries/CorruptCore/StashKey.cs
+++ b/Source/Libraries/CorruptCore/StashKey.cs
@@ -75,6 +75,7 @@ namespace RTCV.CorruptCore
             SystemCore = (string)AllSpec.VanguardSpec?[VSPEC.SYSTEMCORE] ?? "ERROR";
             GameName = (string)AllSpec.VanguardSpec?[VSPEC.GAMENAME] ?? "ERROR";
             SyncSettings = (string)AllSpec.VanguardSpec?[VSPEC.SYNCSETTINGS] ?? "";
+            EmuVer = (string)new DirectoryInfo((string)AllSpec.VanguardSpec[VSPEC.EMUDIR]).Name ?? "";
 
             this.SelectedDomains = ((string[])AllSpec.UISpec[UISPEC.SELECTEDDOMAINS]).ToList();
         }

--- a/Source/Libraries/CorruptCore/Stockpile/Stockpile.cs
+++ b/Source/Libraries/CorruptCore/Stockpile/Stockpile.cs
@@ -607,10 +607,12 @@ namespace RTCV.CorruptCore
             var results = new OperationResults();
 
             var s = (string)AllSpec.VanguardSpec?[VSPEC.NAME] ?? "ERROR";
+            /*
             if (!string.IsNullOrEmpty(sks.VanguardImplementation) && !sks.VanguardImplementation.Equals(s, StringComparison.OrdinalIgnoreCase) && sks.VanguardImplementation != "ERROR")
             {
                 results.AddError($"The stockpile you loaded is for a different Vanguard implementation.\nThe Stockpile reported {sks.VanguardImplementation} but you're connected to {s}.\nThis is a fatal error. Aborting load.");
             }
+            */
             if (sks.RtcVersion != RtcCore.RtcVersion)
             {
                 if (sks.RtcVersion == null)

--- a/Source/Libraries/CorruptCore/Stockpile/StockpileManagerUISide.cs
+++ b/Source/Libraries/CorruptCore/Stockpile/StockpileManagerUISide.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using RTCV.NetCore;
 
@@ -64,7 +65,7 @@ namespace RTCV.CorruptCore
             });
         }
 
-        public static bool ApplyStashkey(StashKey sk, bool loadBeforeOperation = true, bool clearUnitsBeforeApply = true)
+        public static async Task<bool> ApplyStashkey(StashKey sk, bool loadBeforeOperation = true, bool clearUnitsBeforeApply = true)
         {
             PreApplyStashkey(clearUnitsBeforeApply);
 
@@ -72,7 +73,7 @@ namespace RTCV.CorruptCore
 
             if (loadBeforeOperation)
             {
-                if (!LoadState(sk))
+                if (!(await LoadState(sk)))
                 {
                     return isCorruptionApplied;
                 }
@@ -136,7 +137,7 @@ namespace RTCV.CorruptCore
             StashHistory.Add(CurrentStashkey);
         }
 
-        public static bool Corrupt(bool loadBeforeOperation = true)
+        public static async Task<bool> Corrupt(bool loadBeforeOperation = true)
         {
             string saveStateWord = "Savestate";
 
@@ -160,6 +161,15 @@ namespace RTCV.CorruptCore
                 MessageBox.Show($"The Glitch Harvester could not perform the CORRUPT action\n\nEither no {saveStateWord} Box was selected in the {saveStateWord} Manager\nor the {saveStateWord} Box itself is empty.");
                 return false;
             }
+            
+            if (psk.EmuVer != new DirectoryInfo(RtcCore.EmuDir).Name)
+            {
+                {
+                    if (!(await Task.Run(() => LocalNetCoreRouter.QueryRoute<bool>(Endpoints.UI, NetCore.Commands.Remote.SwapImplementation, psk.EmuVer))))
+                        return false;
+                }
+            }
+            
 
             string currentGame = (string)AllSpec.VanguardSpec[VSPEC.GAMENAME];
             string currentCore = (string)AllSpec.VanguardSpec[VSPEC.SYSTEMCORE];
@@ -207,7 +217,7 @@ namespace RTCV.CorruptCore
             StashHistory.RemoveAt(0);
         }
 
-        public static bool InjectFromStashkey(StashKey sk, bool loadBeforeOperation = true)
+        public static async Task<bool> InjectFromStashkey(StashKey sk, bool loadBeforeOperation = true)
         {
             string saveStateWord = "Savestate";
 
@@ -251,7 +261,7 @@ namespace RTCV.CorruptCore
 
             if (loadBeforeOperation)
             {
-                if (!LoadState(CurrentStashkey))
+                if (!(await LoadState(CurrentStashkey)))
                 {
                     return false;
                 }
@@ -272,7 +282,7 @@ namespace RTCV.CorruptCore
             return isCorruptionApplied;
         }
 
-        public static bool OriginalFromStashkey(StashKey sk)
+        public static async Task<bool> OriginalFromStashkey(StashKey sk)
         {
             PreApplyStashkey();
 
@@ -284,7 +294,7 @@ namespace RTCV.CorruptCore
 
             bool isCorruptionApplied = false;
 
-            if (!LoadState(sk, true, false))
+            if (!(await LoadState(sk, true, false)))
             {
                 return isCorruptionApplied;
             }
@@ -293,7 +303,7 @@ namespace RTCV.CorruptCore
             return isCorruptionApplied;
         }
 
-        public static bool MergeStashkeys(List<StashKey> sks, bool loadBeforeOperation = true)
+        public async static Task<bool> MergeStashkeys(List<StashKey> sks, bool loadBeforeOperation = true)
         {
             PreApplyStashkey();
 
@@ -359,7 +369,7 @@ namespace RTCV.CorruptCore
 
                 if (loadBeforeOperation)
                 {
-                    if (!LoadState(CurrentStashkey))
+                    if (!( await LoadState(CurrentStashkey)))
                     {
                         return isCorruptionApplied;
                     }
@@ -383,8 +393,14 @@ namespace RTCV.CorruptCore
             return false;
         }
 
-        public static bool LoadState(StashKey sk, bool reloadRom = true, bool applyBlastLayer = true)
+        public static async Task<bool> LoadState(StashKey sk, bool reloadRom = true, bool applyBlastLayer = true)
         {
+            if (sk.EmuVer != new DirectoryInfo(RtcCore.EmuDir).Name)
+            {
+                if (!(await Task.Run(() => LocalNetCoreRouter.QueryRoute<bool>(Endpoints.UI, NetCore.Commands.Remote.SwapImplementation, sk.EmuVer))))
+                    return false;
+            }
+
             bool success = LocalNetCoreRouter.QueryRoute<bool>(NetCore.Endpoints.CorruptCore, NetCore.Commands.Remote.LoadState, new object[] { sk, reloadRom, applyBlastLayer }, true);
             return success;
         }

--- a/Source/Libraries/CorruptCore/Stockpile/StockpileManagerUISide.cs
+++ b/Source/Libraries/CorruptCore/Stockpile/StockpileManagerUISide.cs
@@ -171,13 +171,18 @@ namespace RTCV.CorruptCore
 
             if (psk.EmuVer != new DirectoryInfo(RtcCore.EmuDir).Name)
             {
-                timeoutTask = Task.Delay(TimeSpan.FromSeconds(timeout));
+                CancellationTokenSource cts = new CancellationTokenSource();
+                timeoutTask = Task.Delay(TimeSpan.FromSeconds(timeout), cts.Token);
                 LocalNetCoreRouter.QueryRoute<bool>(Endpoints.UI, NetCore.Commands.Remote.SwapImplementation, new object[] { psk.EmuVer });
 
                 Task completedTask = await Task.WhenAny(StockpileManagerUISide.finishedSwapping.Task, timeoutTask).ConfigureAwait(false);
                 if (completedTask == timeoutTask)
                 {
                     return false;
+                }
+                else
+                {
+                    cts.Cancel();
                 }
             }
             
@@ -408,13 +413,18 @@ namespace RTCV.CorruptCore
         {
             if (sk.EmuVer != new DirectoryInfo(RtcCore.EmuDir).Name)
             {
-                timeoutTask = Task.Delay(TimeSpan.FromSeconds(timeout));
+                CancellationTokenSource cts = new CancellationTokenSource();
+                timeoutTask = Task.Delay(TimeSpan.FromSeconds(timeout), cts.Token);
                 LocalNetCoreRouter.QueryRoute<bool>(Endpoints.UI, NetCore.Commands.Remote.SwapImplementation, new object[] { sk.EmuVer });
 
                 Task completedTask = await Task.WhenAny(StockpileManagerUISide.finishedSwapping.Task, timeoutTask).ConfigureAwait(false);
                 if (completedTask == timeoutTask)
                 {
                     return false;
+                }
+                else
+                {
+                    cts.Cancel();
                 }
             }
 

--- a/Source/Libraries/CorruptCore/Stockpile/StockpileManagerUISide.cs
+++ b/Source/Libraries/CorruptCore/Stockpile/StockpileManagerUISide.cs
@@ -168,11 +168,11 @@ namespace RTCV.CorruptCore
                 MessageBox.Show($"The Glitch Harvester could not perform the CORRUPT action\n\nEither no {saveStateWord} Box was selected in the {saveStateWord} Manager\nor the {saveStateWord} Box itself is empty.");
                 return false;
             }
-            
+
             if (psk.EmuVer != new DirectoryInfo(RtcCore.EmuDir).Name)
             {
                 timeoutTask = Task.Delay(TimeSpan.FromSeconds(timeout));
-                LocalNetCoreRouter.QueryRoute<bool>(Endpoints.UI, NetCore.Commands.Remote.SwapImplementation, psk.EmuVer);
+                LocalNetCoreRouter.QueryRoute<bool>(Endpoints.UI, NetCore.Commands.Remote.SwapImplementation, new object[] { psk.EmuVer });
 
                 Task completedTask = await Task.WhenAny(StockpileManagerUISide.finishedSwapping.Task, timeoutTask).ConfigureAwait(false);
                 if (completedTask == timeoutTask)
@@ -409,7 +409,7 @@ namespace RTCV.CorruptCore
             if (sk.EmuVer != new DirectoryInfo(RtcCore.EmuDir).Name)
             {
                 timeoutTask = Task.Delay(TimeSpan.FromSeconds(timeout));
-                LocalNetCoreRouter.QueryRoute<bool>(Endpoints.UI, NetCore.Commands.Remote.SwapImplementation, sk.EmuVer);
+                LocalNetCoreRouter.QueryRoute<bool>(Endpoints.UI, NetCore.Commands.Remote.SwapImplementation, new object[] { sk.EmuVer });
 
                 Task completedTask = await Task.WhenAny(StockpileManagerUISide.finishedSwapping.Task, timeoutTask).ConfigureAwait(false);
                 if (completedTask == timeoutTask)

--- a/Source/Libraries/CorruptCore/Stockpile/StockpileManagerUISide.cs
+++ b/Source/Libraries/CorruptCore/Stockpile/StockpileManagerUISide.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using RTCV.NetCore;
@@ -29,6 +30,12 @@ namespace RTCV.CorruptCore
                 _currentStashKey = value;
             }
         }
+
+        public static TaskCompletionSource<bool> finishedClosing;
+        public static TaskCompletionSource<bool> finishedSwapping;
+        public static int timeout = 20;
+        public static Task timeoutTask;
+
         public static StashKey CurrentSavestateStashKey { get; set; }
 
         [SuppressMessage("Microsoft.Design", "CA2211", Justification = "This field cannot be made private or const because it is used by stubs")]
@@ -164,9 +171,13 @@ namespace RTCV.CorruptCore
             
             if (psk.EmuVer != new DirectoryInfo(RtcCore.EmuDir).Name)
             {
+                timeoutTask = Task.Delay(TimeSpan.FromSeconds(timeout));
+                LocalNetCoreRouter.QueryRoute<bool>(Endpoints.UI, NetCore.Commands.Remote.SwapImplementation, psk.EmuVer);
+
+                Task completedTask = await Task.WhenAny(StockpileManagerUISide.finishedSwapping.Task, timeoutTask).ConfigureAwait(false);
+                if (completedTask == timeoutTask)
                 {
-                    if (!(await Task.Run(() => LocalNetCoreRouter.QueryRoute<bool>(Endpoints.UI, NetCore.Commands.Remote.SwapImplementation, psk.EmuVer))))
-                        return false;
+                    return false;
                 }
             }
             
@@ -397,8 +408,14 @@ namespace RTCV.CorruptCore
         {
             if (sk.EmuVer != new DirectoryInfo(RtcCore.EmuDir).Name)
             {
-                if (!(await Task.Run(() => LocalNetCoreRouter.QueryRoute<bool>(Endpoints.UI, NetCore.Commands.Remote.SwapImplementation, sk.EmuVer))))
+                timeoutTask = Task.Delay(TimeSpan.FromSeconds(timeout));
+                LocalNetCoreRouter.QueryRoute<bool>(Endpoints.UI, NetCore.Commands.Remote.SwapImplementation, sk.EmuVer);
+
+                Task completedTask = await Task.WhenAny(StockpileManagerUISide.finishedSwapping.Task, timeoutTask).ConfigureAwait(false);
+                if (completedTask == timeoutTask)
+                {
                     return false;
+                }
             }
 
             bool success = LocalNetCoreRouter.QueryRoute<bool>(NetCore.Endpoints.CorruptCore, NetCore.Commands.Remote.LoadState, new object[] { sk, reloadRom, applyBlastLayer }, true);

--- a/Source/Libraries/CorruptCore/Stockpile/StockpileManagerUISide.cs
+++ b/Source/Libraries/CorruptCore/Stockpile/StockpileManagerUISide.cs
@@ -125,7 +125,8 @@ namespace RTCV.CorruptCore
                 SystemCore = psk.SystemCore,
                 GameName = psk.GameName,
                 SyncSettings = psk.SyncSettings,
-                StateLocation = psk.StateLocation
+                StateLocation = psk.StateLocation,
+                EmuVer = psk.EmuVer
             };
 
 
@@ -175,7 +176,8 @@ namespace RTCV.CorruptCore
                 SystemCore = psk.SystemCore,
                 GameName = psk.GameName,
                 SyncSettings = psk.SyncSettings,
-                StateLocation = psk.StateLocation
+                StateLocation = psk.StateLocation,
+                EmuVer = psk.EmuVer
             };
 
 
@@ -243,7 +245,8 @@ namespace RTCV.CorruptCore
                 SystemCore = psk.SystemCore,
                 GameName = psk.GameName,
                 SyncSettings = psk.SyncSettings,
-                StateLocation = psk.StateLocation
+                StateLocation = psk.StateLocation,
+                EmuVer = psk.EmuVer
             };
 
             if (loadBeforeOperation)
@@ -347,7 +350,8 @@ namespace RTCV.CorruptCore
                     SystemCore = master.SystemCore,
                     GameName = master.GameName,
                     SyncSettings = master.SyncSettings,
-                    StateLocation = master.StateLocation
+                    StateLocation = master.StateLocation,
+                    EmuVer = master.EmuVer
                 };
 
 

--- a/Source/Libraries/CorruptCore/Stockpile/StockpileManagerUISide.cs
+++ b/Source/Libraries/CorruptCore/Stockpile/StockpileManagerUISide.cs
@@ -169,7 +169,7 @@ namespace RTCV.CorruptCore
                 return false;
             }
 
-            if (psk.EmuVer != new DirectoryInfo(RtcCore.EmuDir).Name)
+            if (!String.Equals(psk.EmuVer, new DirectoryInfo(RtcCore.EmuDir).Name, StringComparison.OrdinalIgnoreCase))
             {
                 CancellationTokenSource cts = new CancellationTokenSource();
                 timeoutTask = Task.Delay(TimeSpan.FromSeconds(timeout), cts.Token);
@@ -413,7 +413,7 @@ namespace RTCV.CorruptCore
 
         public static async Task<bool> LoadState(StashKey sk, bool reloadRom = true, bool applyBlastLayer = true)
         {
-            if (sk.EmuVer != new DirectoryInfo(RtcCore.EmuDir).Name)
+            if (!String.Equals(sk.EmuVer, new DirectoryInfo(RtcCore.EmuDir).Name, StringComparison.OrdinalIgnoreCase))
             {
                 CancellationTokenSource cts = new CancellationTokenSource();
                 timeoutTask = Task.Delay(TimeSpan.FromSeconds(timeout), cts.Token);

--- a/Source/Libraries/CorruptCore/Stockpile/StockpileManagerUISide.cs
+++ b/Source/Libraries/CorruptCore/Stockpile/StockpileManagerUISide.cs
@@ -178,6 +178,7 @@ namespace RTCV.CorruptCore
                 Task completedTask = await Task.WhenAny(StockpileManagerUISide.finishedSwapping.Task, timeoutTask).ConfigureAwait(false);
                 if (completedTask == timeoutTask)
                 {
+                    LocalNetCoreRouter.Route(Endpoints.UI, NetCore.Commands.Remote.UnlockInterface, true);
                     return false;
                 }
                 else
@@ -225,6 +226,7 @@ namespace RTCV.CorruptCore
             }
 
             PostApplyStashkey(CurrentStashkey);
+            LocalNetCoreRouter.Route(Endpoints.UI, NetCore.Commands.Remote.UnlockInterface, true);
             return isCorruptionApplied;
         }
 
@@ -420,6 +422,7 @@ namespace RTCV.CorruptCore
                 Task completedTask = await Task.WhenAny(StockpileManagerUISide.finishedSwapping.Task, timeoutTask).ConfigureAwait(false);
                 if (completedTask == timeoutTask)
                 {
+                    LocalNetCoreRouter.Route(Endpoints.UI, NetCore.Commands.Remote.UnlockInterface, true);
                     return false;
                 }
                 else
@@ -429,6 +432,7 @@ namespace RTCV.CorruptCore
             }
 
             bool success = LocalNetCoreRouter.QueryRoute<bool>(NetCore.Endpoints.CorruptCore, NetCore.Commands.Remote.LoadState, new object[] { sk, reloadRom, applyBlastLayer }, true);
+            LocalNetCoreRouter.Route(Endpoints.UI, NetCore.Commands.Remote.UnlockInterface, true);
             return success;
         }
 

--- a/Source/Libraries/NetCore/NetcoreCommands.cs
+++ b/Source/Libraries/NetCore/NetcoreCommands.cs
@@ -93,6 +93,7 @@ namespace RTCV.NetCore.Commands
         public const string KeySetSystemCore = nameof(Remote) + "_" + nameof(KeySetSystemCore);
 
         public const string SwapImplementation = nameof(Remote) + "_" + nameof(SwapImplementation);
+        public const string UnlockInterface = nameof(Remote) + "_" + nameof(UnlockInterface);
         
         //HOTKEYS
         public const string HotkeyManualBlast = nameof(Remote) + "_" + nameof(HotkeyManualBlast);

--- a/Source/Libraries/NetCore/NetcoreCommands.cs
+++ b/Source/Libraries/NetCore/NetcoreCommands.cs
@@ -91,6 +91,8 @@ namespace RTCV.NetCore.Commands
         public const string BlastToolsGetAppliedBackupLayer = nameof(Remote) + "_" + nameof(BlastToolsGetAppliedBackupLayer);
         public const string KeySetSyncSettings = nameof(Remote) + "_" + nameof(KeySetSyncSettings);
         public const string KeySetSystemCore = nameof(Remote) + "_" + nameof(KeySetSystemCore);
+
+        public const string SwapImplementation = nameof(Remote) + "_" + nameof(SwapImplementation);
         
         //HOTKEYS
         public const string HotkeyManualBlast = nameof(Remote) + "_" + nameof(HotkeyManualBlast);

--- a/Source/Libraries/NetCore/UDPLink.cs
+++ b/Source/Libraries/NetCore/UDPLink.cs
@@ -6,6 +6,7 @@ namespace RTCV.NetCore
     using System.Net.Sockets;
     using System.Text;
     using System.Threading;
+    using System.Windows.Forms;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
     using RTCV.NetCore.Enums;
@@ -140,9 +141,10 @@ namespace RTCV.NetCore
                     if (bytes != null)
                     {
                         string byteString = Encoding.UTF8.GetString(bytes, 0, bytes.Length);
-                        // if there's more than one element, it's an advanced message
-                        if (byteString.Contains(","))
-                        { 
+
+                        // if there's an objectValue, it's an advanced message
+                        if (byteString.Contains("objectValue"))
+                        {
                             NetCoreAdvancedMessage message = JsonConvert.DeserializeObject<NetCoreAdvancedMessage>(byteString);
                             JArray jArray = (JArray)message.objectValue;
                             message.objectValue = jArray.ToObject<List<object>>().ToArray();

--- a/Source/Libraries/NetCore/UDPLink.cs
+++ b/Source/Libraries/NetCore/UDPLink.cs
@@ -1,10 +1,13 @@
 namespace RTCV.NetCore
 {
     using System;
+    using System.Collections.Generic;
     using System.Net;
     using System.Net.Sockets;
     using System.Text;
     using System.Threading;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
     using RTCV.NetCore.Enums;
 
     public class UDPLink : IDisposable
@@ -136,7 +139,19 @@ namespace RTCV.NetCore
                     }
                     if (bytes != null)
                     {
-                        spec.Connector.hub.QueueMessage(new NetCoreSimpleMessage(Encoding.ASCII.GetString(bytes, 0, bytes.Length)));
+                        string byteString = Encoding.UTF8.GetString(bytes, 0, bytes.Length);
+                        // if there's more than one element, it's an advanced message
+                        if (byteString.Contains(","))
+                        { 
+                            NetCoreAdvancedMessage message = JsonConvert.DeserializeObject<NetCoreAdvancedMessage>(byteString);
+                            JArray jArray = (JArray)message.objectValue;
+                            message.objectValue = jArray.ToObject<List<object>>().ToArray();
+                            spec.Connector.hub.QueueMessage(message);
+                        }
+                        else
+                        {
+                            spec.Connector.hub.QueueMessage(new NetCoreSimpleMessage(byteString));
+                        }
                     }
 
                     //Sleep if there's no more data


### PR DESCRIPTION
This PR adds the ability to swap between emulators without closing down StandaloneRTC.exe. This gives us the benefit of not having to save/close any work that is currently ongoing in RTC, and opens up the ability to swap implementations gracefully without using /taskkill. It also allows cross emulator stockpiles to be created, as it can seamlessly swap between emulators and load stockpiles.